### PR TITLE
chore: move `globals` to `peerDependencies` and support version 14+

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "*": "prettier --ignore-unknown --write"
   },
   "dependencies": {
-    "commander": "^13.1.0",
-    "globals": "^16.0.0"
+    "commander": "^13.1.0"
+  },
+  "peerDependencies": {
+    "globals": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "packageManager": "pnpm@10.6.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       globals:
-        specifier: ^16.0.0
+        specifier: ^14.0.0 || ^15.0.0 || ^16.0.0
         version: 16.0.0
     devDependencies:
       '@antfu/eslint-config':


### PR DESCRIPTION
closes #71