### PR TITLE
chore(vscode): remove vscode formatter for typescript and json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,11 +7,5 @@
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "never"
   },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[json]": {
-    "editor.defaultFormatter": "vscode.json-language-features"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
Use prettier for everything. Like the CLI and husky hooks.