### PR TITLE
chore: requires latest `globals` npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
   },
   "dependencies": {
     "commander": "^14.0.0",
+    "globals": "^16.3.0",
     "oxc-parser": "^0.87.0",
     "tinyglobby": "^0.2.14"
   },
   "peerDependencies": {
-    "globals": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "jiti": "*"
   },
   "packageManager": "pnpm@10.15.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       globals:
-        specifier: ^14.0.0 || ^15.0.0 || ^16.0.0
+        specifier: ^16.3.0
         version: 16.3.0
       oxc-parser:
         specifier: ^0.87.0


### PR DESCRIPTION
closes #170

Because `oxlint` is using an own sync of `globals`: https://github.com/oxc-project/javascript-globals, `@oxlint/migrate` should respect the entries which is found by `javascript-globals/oxlint`.

See https://github.com/oxc-project/javascript-globals/issues/69