### PR TITLE
fix: correct assignment operators

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,6 +6,8 @@
   },
   "rules": {
     "unicorn/prefer-set-has": "off",
+    "no-unused-expressions": ["error", { "allowShortCircuit": true }],
+    "eqeqeq": ["error", "always"],
     "@typescript-eslint/no-array-delete": "off" // FIXME
   }
 }

--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -35,14 +35,14 @@ const normalizeSeverityValue = (value: Linter.RuleEntry | undefined) => {
 
   if (isWarnValue(value)) {
     if (Array.isArray(value)) {
-      value[0] == 'warn';
+      value[0] = 'warn';
       return value;
     }
 
     return 'warn';
   } else if (isErrorValue(value)) {
     if (Array.isArray(value)) {
-      value[0] == 'error';
+      value[0] = 'error';
       return value;
     }
 
@@ -51,7 +51,7 @@ const normalizeSeverityValue = (value: Linter.RuleEntry | undefined) => {
 
   if (isOffValue(value)) {
     if (Array.isArray(value)) {
-      value[0] == 'off';
+      value[0] = 'off';
       return value;
     }
 


### PR DESCRIPTION
This PR fixes a bug where comparison operators (==) were mistakenly used instead of assignment operators (=) in the normalizeSeverityValue function.

This question seems strange, was it intended to be that way? 🤔