### PR TITLE
fix: replace eslint comments in `jsx` and `tsx` files too

### DIFF
--- a/bin/project-loader.ts
+++ b/bin/project-loader.ts
@@ -3,7 +3,7 @@ import { glob } from 'tinyglobby';
 export const getAllProjectFiles = (): Promise<string[]> => {
   return glob(
     [
-      '**/*.{js,cjs,mjs,ts,cts,mts,vue,astro,svelte}',
+      '**/*.{js,cjs,mjs,ts,cts,mts,jsx,tsx,vue,astro,svelte}',
       '!**/node_modules/**',
       '!**/dist/**',
     ],


### PR DESCRIPTION
closes https://github.com/oxc-project/oxlint-migrate/issues/246