### PR TITLE
chore: Use `oxfmt --no-error-on-unmatched-pattern` flag in lint-staged.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vitest": "^4.0.0"
   },
   "lint-staged": {
-    "*": "oxfmt ."
+    "*": "oxfmt --no-error-on-unmatched-pattern"
   },
   "dependencies": {
     "commander": "^14.0.0",


### PR DESCRIPTION
This way we can avoid errors when there are no matching files without needing to specify a `.` for the path. I had somehow missed that this flag existed 😓 