### PR TITLE
feat(linter/vitest): prefer-mock-return-shorthand rule vitest compatible

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -49,6 +49,7 @@ export const viteTestCompatibleRules = [
   'prefer-hooks-on-top',
   'prefer-lowercase-title',
   'prefer-mock-promise-shorthand',
+  'prefer-mock-return-shorthand',
   'prefer-spy-on',
   'prefer-strict-equal',
   'prefer-to-be',


### PR DESCRIPTION
Depends on: https://github.com/oxc-project/oxc/pull/18002