### PR TITLE
refactor: mark `no-unneeded-async-expect-function` as vitest compatible

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -39,6 +39,7 @@ export const viteTestCompatibleRules = [
   'no-standalone-expect',
   'no-test-prefixes',
   'no-test-return-statement',
+  'no-unneeded-async-expect-function',
   'prefer-called-with',
   'prefer-comparison-matcher',
   'prefer-each',


### PR DESCRIPTION
this PR marks `no-unneeded-async-expect-function` as vitest compatible for this PR https://github.com/oxc-project/oxc/pull/18397