### PR TITLE
docs: Add a section on Caveats to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When no config file is provided, the script searches for the default ESLint conf
 | Options                     | Description                                                                                                                                 |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--merge`                   | \* merge ESLint configuration with an existing .oxlintrc.json configuration                                                                 |
-| `--type-aware`              | Include type aware rules, which are supported with `oxlint --type-aware`                                                                    |
+| `--type-aware`              | Include type aware rules, which are supported with `oxlint --type-aware` and [oxlint-tsgolint](https://github.com/oxc-project/tsgolint)     |
 | `--with-nursery`            | Include oxlint rules which are currently under development                                                                                  |
 | `--js-plugins`              | \*\* Include ESLint plugins via `jsPlugins` key.                                                                                            |
 | `--output-file <file>`      | The oxlint configuration file where ESLint v9 rules will be written to, default: `.oxlintrc.json`                                           |


### PR DESCRIPTION
Include some notes on what may not migrate perfectly right now, to help users migrate complex setups from ESLint. Basically just noting some things users may need to migrate manually right now/may explain problems if they run into them.

Also add a link to the Oxlint docs page about migrating from ESLint.