### PR TITLE
fix: do not remove rules from overrides where conflict with earlier override

### DIFF
--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -372,11 +372,21 @@ export const cleanUpUselessOverridesRules = (config: OxlintConfig): void => {
     // Update the first override with the final merged rules
     firstOverride.rules = entry.finalRules;
 
-    // Remove rules that match root config
+    // Remove rules that match root config.
+    // Exception is if a previous override has the same rule, in which case this override needs
+    // to re-assert the root value.
+    // Note that if previous override had same value as root, it would have been removed already.
     if (firstOverride.rules) {
       for (const [rule, settings] of Object.entries(firstOverride.rules)) {
         if (config.rules[rule] === settings) {
-          delete firstOverride.rules[rule];
+          // The override has same rule as root with same setting.
+          // Check if any previous override potentially overrides root.
+          const previousOverrideHasRule = config.overrides
+            .slice(0, entry.firstIndex)
+            .some((prev) => prev.rules?.[rule] !== undefined);
+          if (!previousOverrideHasRule) {
+            delete firstOverride.rules[rule];
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #386.

ESLint config:

```js
export default [
  {
    rules: { "accessor-pairs": "error" },
  },
  {
    files: ["*.js"],
    rules: { "accessor-pairs": "off" },
  },
  {
    files: ["*.test.js"],
    rules: { "accessor-pairs": "error" },
  },
];
```

Generated Oxlint config before this PR:

```json
{
  ...
  "rules": { "accessor-pairs": "error" },
  "overrides": [
    {
      "files": ["*.js"],
      "rules": { "accessor-pairs": "off" }
    }
  ]
}
```

After:

```json
{
  ...
  "rules": { "accessor-pairs": "error" },
  "overrides": [
    {
      "files": ["*.js"],
      "rules": { "accessor-pairs": "off" }
    },
    {
      "files": ["*.test.js"],
      "rules": { "accessor-pairs": "error" }
    }
  ]
}
```

The `*.test.js` override is now preserved - which it needs to be because otherwise rule is `"off"` for `*.test.js` files, due to the previous override.

This PR takes a simple and conservative approach and assumes *any* previous override with same rule might conflict with the current one. If 1st override had `"files": ["*.ts"]` then we could in fact remove the 3rd override because a file can't match both globs `*.ts` and `*.test.js`. But we don't calculate glob intersection to determine this, so we err on safe side and keep both.