### PR TITLE
fix: only merge overrides with same files if consecutive

### DIFF
--- a/integration_test/__snapshots__/many-extends.spec.ts.snap
+++ b/integration_test/__snapshots__/many-extends.spec.ts.snap
@@ -28,6 +28,9 @@ exports[`many-extends.spec.ts > many-extends.spec.ts 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": "error",
@@ -113,15 +116,6 @@ exports[`many-extends.spec.ts > many-extends.spec.ts 1`] = `
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [
@@ -373,6 +367,9 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": "error",
@@ -458,15 +455,6 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [
@@ -718,6 +706,9 @@ exports[`many-extends.spec.ts --type-aware > many-extends.spec.ts--type-aware 1`
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": "error",
@@ -864,15 +855,6 @@ exports[`many-extends.spec.ts --type-aware > many-extends.spec.ts--type-aware 1`
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [
@@ -1085,6 +1067,9 @@ exports[`many-extends.spec.ts merge > many-extends.spec.ts--merge 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": "error",
@@ -1181,15 +1166,6 @@ exports[`many-extends.spec.ts merge > many-extends.spec.ts--merge 1`] = `
           "react/react-in-jsx-scope": "off",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [

--- a/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
+++ b/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
@@ -131,6 +131,7 @@ exports[`nuxt-auth > nuxt-auth 1`] = `
         ],
         "plugins": [
           "node",
+          "jsdoc",
         ],
         "rules": {
           "jsdoc/check-access": "warn",
@@ -149,17 +150,12 @@ exports[`nuxt-auth > nuxt-auth 1`] = `
       },
       {
         "files": [
-          "**/*.?([cm])[jt]s?(x)",
-        ],
-        "plugins": [
-          "jsdoc",
-        ],
-      },
-      {
-        "files": [
           "**/*.?([cm])ts",
           "**/*.?([cm])tsx",
           "**/*.vue",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
@@ -253,16 +249,6 @@ exports[`nuxt-auth > nuxt-auth 1`] = `
             },
           ],
         },
-      },
-      {
-        "files": [
-          "**/*.?([cm])ts",
-          "**/*.?([cm])tsx",
-          "**/*.vue",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -1083,6 +1069,7 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         ],
         "plugins": [
           "node",
+          "jsdoc",
         ],
         "rules": {
           "jsdoc/check-access": "warn",
@@ -1101,17 +1088,12 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
       },
       {
         "files": [
-          "**/*.?([cm])[jt]s?(x)",
-        ],
-        "plugins": [
-          "jsdoc",
-        ],
-      },
-      {
-        "files": [
           "**/*.?([cm])ts",
           "**/*.?([cm])tsx",
           "**/*.vue",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
@@ -1205,16 +1187,6 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
             },
           ],
         },
-      },
-      {
-        "files": [
-          "**/*.?([cm])ts",
-          "**/*.?([cm])tsx",
-          "**/*.vue",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -2435,6 +2407,7 @@ exports[`nuxt-auth --type-aware > nuxt-auth--type-aware 1`] = `
         ],
         "plugins": [
           "node",
+          "jsdoc",
         ],
         "rules": {
           "jsdoc/check-access": "warn",
@@ -2453,17 +2426,12 @@ exports[`nuxt-auth --type-aware > nuxt-auth--type-aware 1`] = `
       },
       {
         "files": [
-          "**/*.?([cm])[jt]s?(x)",
-        ],
-        "plugins": [
-          "jsdoc",
-        ],
-      },
-      {
-        "files": [
           "**/*.?([cm])ts",
           "**/*.?([cm])tsx",
           "**/*.vue",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
@@ -2557,16 +2525,6 @@ exports[`nuxt-auth --type-aware > nuxt-auth--type-aware 1`] = `
             },
           ],
         },
-      },
-      {
-        "files": [
-          "**/*.?([cm])ts",
-          "**/*.?([cm])tsx",
-          "**/*.vue",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -3379,6 +3337,7 @@ exports[`nuxt-auth merge > nuxt-auth--merge 1`] = `
         ],
         "plugins": [
           "node",
+          "jsdoc",
         ],
         "rules": {
           "jsdoc/check-access": "warn",
@@ -3397,17 +3356,12 @@ exports[`nuxt-auth merge > nuxt-auth--merge 1`] = `
       },
       {
         "files": [
-          "**/*.?([cm])[jt]s?(x)",
-        ],
-        "plugins": [
-          "jsdoc",
-        ],
-      },
-      {
-        "files": [
           "**/*.?([cm])ts",
           "**/*.?([cm])tsx",
           "**/*.vue",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
@@ -3496,16 +3450,6 @@ exports[`nuxt-auth merge > nuxt-auth--merge 1`] = `
           "no-with": "off",
           "prefer-const": "error",
         },
-      },
-      {
-        "files": [
-          "**/*.?([cm])ts",
-          "**/*.?([cm])tsx",
-          "**/*.vue",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [

--- a/integration_test/__snapshots__/pupeeteer.spec.ts.snap
+++ b/integration_test/__snapshots__/pupeeteer.spec.ts.snap
@@ -57,6 +57,9 @@ exports[`puppeteer > puppeteer 1`] = `
         "files": [
           "**/*.ts",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": [
@@ -129,14 +132,6 @@ exports[`puppeteer > puppeteer 1`] = `
           "prefer-rest-params": "error",
           "prefer-spread": "error",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -356,6 +351,12 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
         "files": [
           "**/*.ts",
         ],
+        "jsPlugins": [
+          "@puppeteer/eslint-plugin",
+        ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@puppeteer/use-using": "error",
           "@typescript-eslint/adjacent-overload-signatures": "error",
@@ -429,25 +430,6 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
           "prefer-rest-params": "error",
           "prefer-spread": "error",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-        ],
-        "plugins": [
-          "typescript",
-        ],
-      },
-      {
-        "files": [
-          "**/*.ts",
-        ],
-        "jsPlugins": [
-          "@puppeteer/eslint-plugin",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -673,6 +655,9 @@ exports[`puppeteer --type-aware > puppeteer--type-aware 1`] = `
         "files": [
           "**/*.ts",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": [
@@ -757,14 +742,6 @@ exports[`puppeteer --type-aware > puppeteer--type-aware 1`] = `
           "prefer-rest-params": "error",
           "prefer-spread": "error",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [
@@ -987,6 +964,9 @@ exports[`puppeteer merge > puppeteer--merge 1`] = `
         "files": [
           "**/*.ts",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/adjacent-overload-signatures": "error",
           "@typescript-eslint/array-type": [
@@ -1059,14 +1039,6 @@ exports[`puppeteer merge > puppeteer--merge 1`] = `
           "prefer-rest-params": "error",
           "prefer-spread": "error",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
       {
         "files": [

--- a/integration_test/__snapshots__/typescript-simple.spec.ts.snap
+++ b/integration_test/__snapshots__/typescript-simple.spec.ts.snap
@@ -16,6 +16,9 @@ exports[`typescript-simple > typescript-simple 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
             "error",
@@ -72,15 +75,6 @@ exports[`typescript-simple > typescript-simple 1`] = `
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [],
@@ -161,6 +155,9 @@ exports[`typescript-simple --js-plugins > typescript-simple--js-plugins 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "plugins": [
+          "typescript",
+        ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
             "error",
@@ -217,15 +214,6 @@ exports[`typescript-simple --js-plugins > typescript-simple--js-plugins 1`] = `
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [],
@@ -305,6 +293,9 @@ exports[`typescript-simple --type-aware > typescript-simple--type-aware 1`] = `
         "files": [
           "**/*.ts",
           "**/*.tsx",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/await-thenable": "error",
@@ -421,15 +412,6 @@ exports[`typescript-simple --type-aware > typescript-simple--type-aware 1`] = `
           "require-await": "off",
         },
       },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
-      },
     ],
     "plugins": [],
     "rules": {
@@ -472,6 +454,9 @@ exports[`typescript-simple merge > typescript-simple--merge 1`] = `
         "files": [
           "**/*.ts",
           "**/*.tsx",
+        ],
+        "plugins": [
+          "typescript",
         ],
         "rules": {
           "@typescript-eslint/ban-ts-comment": [
@@ -529,15 +514,6 @@ exports[`typescript-simple merge > typescript-simple--merge 1`] = `
           "prefer-spread": "error",
           "require-await": "off",
         },
-      },
-      {
-        "files": [
-          "**/*.ts",
-          "**/*.tsx",
-        ],
-        "plugins": [
-          "typescript",
-        ],
       },
     ],
     "plugins": [],

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -86,8 +86,7 @@ const cleanUpUselessOverridesEntries = (config: OxlintConfig): void => {
     (overrides) => Object.keys(overrides).length > 0
   );
 
-  // Merge consecutive identical overrides to avoid redundancy
-  mergeConsecutiveIdenticalOverrides(config);
+  // Merge consecutive overrides that are identical except for their `files` property, to avoid repetition
   mergeConsecutiveOverridesWithDifferingFiles(config);
 
   if (config.overrides.length === 0) {
@@ -134,74 +133,6 @@ export const cleanUpOxlintConfig = (config: OxlintConfigOrOverride): void => {
     cleanUpDisabledRootRules(config);
   }
 };
-
-/**
- * Merges consecutive identical overrides in the config's overrides array
- * Merges only if the overrides are directly next to each other
- * (otherwise they could be overriden in between one another).
- *
- * Example:
- *
- * ```json
- * overrides: [
- *   {
- *     "files": [
- *       "*.ts",
- *       "*.tsx",
- *     ],
- *     "plugins": [
- *       "typescript",
- *     ],
- *   },
- *    {
- *      "files": [
- *        "*.ts",
- *        "*.tsx",
- *      ],
- *      "plugins": [
- *        "typescript",
- *      ],
- *    },
- * ]
- * ```
- */
-function mergeConsecutiveIdenticalOverrides(config: OxlintConfig) {
-  if (config.overrides === undefined) {
-    return;
-  }
-  if (config.overrides.length <= 1) {
-    return;
-  }
-
-  const mergedOverrides: OxlintConfigOverride[] = [];
-  let i = 0;
-
-  while (i < config.overrides.length) {
-    const current = config.overrides[i];
-
-    // Check if the next override is identical to the current one
-    if (
-      i + 1 < config.overrides.length &&
-      isEqualDeep(current, config.overrides[i + 1])
-    ) {
-      // Skip duplicates - just add the first one
-      mergedOverrides.push(current);
-      // Skip all consecutive duplicates
-      while (
-        i + 1 < config.overrides.length &&
-        isEqualDeep(current, config.overrides[i + 1])
-      ) {
-        i++;
-      }
-    } else {
-      mergedOverrides.push(current);
-    }
-
-    i++;
-  }
-
-  config.overrides = mergedOverrides;
-}
 
 /**
  * Merge consecutive overrides that have differing files but everything else is identical.

--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -12,7 +12,7 @@ import {
   typescriptRulesExtendEslintRules,
 } from './constants.js';
 import { enableJsPluginRule, isIgnoredPluginRule } from './jsPlugins.js';
-import { buildUnsupportedRuleExplanations } from './utilities.js';
+import { buildUnsupportedRuleExplanations, isEqualDeep } from './utilities.js';
 
 const allRules = Object.values(rules).flat();
 const unsupportedRuleExplanations = buildUnsupportedRuleExplanations();
@@ -324,81 +324,93 @@ export const cleanUpUselessOverridesPlugins = (config: OxlintConfig): void => {
 };
 
 export const cleanUpUselessOverridesRules = (config: OxlintConfig): void => {
-  if (config.rules === undefined || config.overrides === undefined) {
+  if (config.overrides === undefined) {
     return;
   }
 
-  // Build a map of files pattern -> {firstOverrideIndex, finalMergedRules}
-  const filesPatternMap = new Map<
-    string,
-    {
-      firstIndex: number;
-      finalRules: Record<string, Linter.RuleEntry>;
-      indicesToRemove: number[];
-    }
-  >();
+  for (let i = 0; i < config.overrides.length; i++) {
+    const current = config.overrides[i];
 
-  // First pass: merge all overrides with same files pattern
-  for (const [i, override] of config.overrides.entries()) {
-    if (override.files === undefined) {
-      continue;
-    }
-
-    const filesKey = JSON.stringify(override.files);
-    let entry = filesPatternMap.get(filesKey);
-
-    if (!entry) {
-      entry = {
-        firstIndex: i,
-        finalRules: {},
-        indicesToRemove: [],
-      };
-      filesPatternMap.set(filesKey, entry);
-    } else {
-      // Mark this duplicate for removal
-      entry.indicesToRemove.push(i);
+    // Merge consecutive same-files overrides into prev and splice out current.
+    // Non-consecutive same-files overrides must NOT be merged — intervening
+    // overrides with overlapping file patterns would change precedence.
+    if (i > 0) {
+      const previous = config.overrides[i - 1];
+      if (isEqualDeep(previous.files, current.files)) {
+        mergeOverrideProperties(previous, current);
+        config.overrides.splice(i, 1);
+        i -= 2; // re-process prev (merge may have changed root-matching)
+        continue;
+      }
     }
 
-    // Merge rules with last-wins semantics
-    if (override.rules) {
-      Object.assign(entry.finalRules, override.rules);
+    // Remove rules matching root config
+    removeRootMatchingRules(config, i);
+  }
+};
+
+/** Merge all properties from `source` into `target` (same-files overrides). */
+const mergeOverrideProperties = (
+  target: OxlintConfigOverride,
+  source: OxlintConfigOverride
+): void => {
+  // Rules: last-wins per key
+  if (source.rules) {
+    target.rules = { ...target.rules, ...source.rules };
+  }
+
+  // Array properties: union
+  if (source.plugins) {
+    target.plugins = [
+      ...new Set([...(target.plugins ?? []), ...source.plugins]),
+    ];
+  }
+  if (source.jsPlugins) {
+    target.jsPlugins = [
+      ...new Set([...(target.jsPlugins ?? []), ...source.jsPlugins]),
+    ];
+  }
+
+  // Object properties: last-wins per key
+  if (source.env) {
+    target.env = { ...target.env, ...source.env };
+  }
+  if (source.globals) {
+    target.globals = { ...target.globals, ...source.globals };
+  }
+  if (source.categories) {
+    target.categories = { ...target.categories, ...source.categories };
+  }
+};
+
+/**
+ * Remove rules from `config.overrides[overrideIndex]` that match root config,
+ * unless a previous override also has the rule (meaning it overrides root with
+ * a different value — same-as-root rules are removed earlier in the loop).
+ */
+const removeRootMatchingRules = (
+  config: OxlintConfig,
+  overrideIndex: number
+): void => {
+  const override = config.overrides![overrideIndex];
+
+  if (!override.rules || !config.rules) {
+    return;
+  }
+
+  for (const [rule, settings] of Object.entries(override.rules)) {
+    if (config.rules[rule] === settings) {
+      const previousOverrideHasRule = config
+        .overrides!.slice(0, overrideIndex)
+        .some((prev) => prev.rules?.[rule] !== undefined);
+      if (!previousOverrideHasRule) {
+        delete override.rules[rule];
+      }
     }
   }
 
-  // Second pass: update first occurrence with merged rules and mark duplicates for deletion
-  for (const entry of filesPatternMap.values()) {
-    const firstOverride = config.overrides[entry.firstIndex];
-
-    // Update the first override with the final merged rules
-    firstOverride.rules = entry.finalRules;
-
-    // Remove rules that match root config.
-    // Exception is if a previous override has the same rule, in which case this override needs
-    // to re-assert the root value.
-    // Note that if previous override had same value as root, it would have been removed already.
-    if (firstOverride.rules) {
-      for (const [rule, settings] of Object.entries(firstOverride.rules)) {
-        if (config.rules[rule] === settings) {
-          // The override has same rule as root with same setting.
-          // Check if any previous override potentially overrides root.
-          const previousOverrideHasRule = config.overrides
-            .slice(0, entry.firstIndex)
-            .some((prev) => prev.rules?.[rule] !== undefined);
-          if (!previousOverrideHasRule) {
-            delete firstOverride.rules[rule];
-          }
-        }
-      }
-
-      if (Object.keys(firstOverride.rules).length === 0) {
-        delete firstOverride.rules;
-      }
-    }
-
-    // Mark duplicate overrides for removal by clearing their rules
-    for (const indexToRemove of entry.indicesToRemove) {
-      delete config.overrides[indexToRemove].rules;
-    }
+  if (Object.keys(override.rules).length === 0) {
+    delete override.rules;
   }
 };
 


### PR DESCRIPTION
Rewrite `cleanUpUselessOverridesRules` to fix a bug, and make a couple of related improvements.

### 1. Bug: Non-consecutive same-files overrides merged incorrectly

ESLint config:

```js
export default [
  {
    rules: { "no-debugger": "error" },
  },
  {
    files: ["*.test.js"],
    rules: { "accessor-pairs": "warn" },
  },
  {
    files: ["*.js"],
    rules: { "accessor-pairs": "error" },
  },
  {
    files: ["*.test.js"],
    rules: { "accessor-pairs": "off" },
  },
];
```

Generated Oxlint config before this PR:

```json
{
  "rules": { "no-debugger": "error" },
  "overrides": [
    {
      "files": ["*.test.js"],
      "rules": { "accessor-pairs": "off" }
    },
    {
      "files": ["*.js"],
      "rules": { "accessor-pairs": "error" }
    }
  ]
}
```

After:

```json
{
  "rules": { "no-debugger": "error" },
  "overrides": [
    {
      "files": ["*.test.js"],
      "rules": { "accessor-pairs": "warn" }
    },
    {
      "files": ["*.js"],
      "rules": { "accessor-pairs": "error" }
    },
    {
      "files": ["*.test.js"],
      "rules": { "accessor-pairs": "off" }
    }
  ]
}
```

In ESLint, `*.test.js` files would have the rule turned off as the last entry took priority, but in Oxlint config before this PR, the rule was enabled as `error`, as the `*.js` override takes priority.

This PR fixes it by only merging 2 entries with same `files` if they are directly consecutive.

Same as #387, we could merge more aggressively in some cases if we checked whether the `files` globs of any intermediate entries intersect with the `files` of the entries we wish to merge. If entry 1 and entry 3 have `files: ["*.js"]`, and entry 2 has `files: ["*.ts"]` then they can't affect any of the same files, and entries 1 + 3 could be merged. This PR does not add this complication.

This change also allows simplifying the implementation to a single loop, rather than a 2-pass approach.

### 2. Improvement: Only rules were merged, not other override properties

When merging same-`files` overrides, only rules were merged. Other properties (`plugins`, `jsPlugins`, `globals`, `env`, `categories`) stayed on the later override.

Before:

```json
{
  "overrides": [
    {
      "files": ["**/*.ts", "**/*.tsx"],
      "rules": { "@typescript-eslint/ban-ts-comment": "error" }
    },
    {
      "files": ["**/*.ts", "**/*.tsx"],
      "plugins": ["typescript"]
    }
  ]
}
```

After:

```json
{
  "overrides": [
    {
      "files": ["**/*.ts", "**/*.tsx"],
      "plugins": ["typescript"],
      "rules": { "@typescript-eslint/ban-ts-comment": "error" }
    }
  ]
}
```

Now all properties are merged:

* `rules`, `env`, `globals`, and `categories` are merged with last-wins per key.
* `plugins`, and `jsPlugins` are merged as union of all entries.

The old output was not incorrect, as Oxlint would merge the overrides when loading the config. But it makes for a smaller config.

With this change, `mergeConsecutiveIdenticalOverrides` is redundant and can be removed. If two consecutive overrides are completely identical, that implies that they have the same `files`, so `cleanUpUselessOverridesRules` will have already merged them before `mergeConsecutiveIdenticalOverrides` was called.

### 3. Improvement: Merge overrides when root config has no rules

The early return `if (config.rules === undefined || config.overrides === undefined)` at top of `cleanUpUselessOverridesRules` prevented consecutive same-`files` overrides from being merged when there are no root rules.

Again this did not create an incorrect config, just one that was larger than it needed to be.