### PR TITLE
feat: convert unsupported ESLint rules to JS plugins

### DIFF
--- a/integration_test/__snapshots__/autoprefixer.spec.ts.snap
+++ b/integration_test/__snapshots__/autoprefixer.spec.ts.snap
@@ -343,6 +343,7 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
     ],
     "jsPlugins": [
       "eslint-plugin-perfectionist",
+      "oxlint-plugin-eslint",
       "eslint-plugin-prefer-let",
     ],
     "overrides": [
@@ -397,6 +398,44 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
         "always",
         {
           "null": "ignore",
+        },
+      ],
+      "eslint-js/camelcase": [
+        "error",
+        {
+          "allow": [
+            "^UNSAFE_",
+          ],
+          "ignoreGlobals": true,
+          "properties": "never",
+        },
+      ],
+      "eslint-js/dot-notation": [
+        "error",
+        {
+          "allowKeywords": true,
+        },
+      ],
+      "eslint-js/func-name-matching": "error",
+      "eslint-js/no-dupe-args": "error",
+      "eslint-js/no-implied-eval": "error",
+      "eslint-js/no-invalid-this": "error",
+      "eslint-js/no-octal": "error",
+      "eslint-js/no-octal-escape": "error",
+      "eslint-js/no-undef-init": "error",
+      "eslint-js/no-unreachable-loop": "error",
+      "eslint-js/object-shorthand": "error",
+      "eslint-js/one-var": [
+        "error",
+        {
+          "initialized": "never",
+        },
+      ],
+      "eslint-js/prefer-arrow-callback": "error",
+      "eslint-js/prefer-regex-literals": [
+        "error",
+        {
+          "disallowRedundantWrapping": true,
         },
       ],
       "for-direction": "error",
@@ -752,7 +791,6 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
   "skipped": {
     "js-plugins": [],
     "not-implemented": [
-      "func-name-matching",
       "n/handle-callback-err",
       "n/no-deprecated-api",
       "n/no-extraneous-require",
@@ -762,12 +800,6 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
       "n/no-unsupported-features/es-syntax",
       "n/no-unsupported-features/node-builtins",
       "n/process-exit-as-throw",
-      "no-implied-eval",
-      "no-unreachable-loop",
-      "object-shorthand",
-      "one-var",
-      "prefer-arrow-callback",
-      "prefer-regex-literals",
     ],
     "nursery": [
       "getter-return",
@@ -776,15 +808,7 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
       "no-unreachable",
     ],
     "type-aware": [],
-    "unsupported": [
-      "camelcase",
-      "dot-notation",
-      "no-dupe-args",
-      "no-invalid-this",
-      "no-octal",
-      "no-octal-escape",
-      "no-undef-init",
-    ],
+    "unsupported": [],
   },
   "warnings": [],
 }

--- a/integration_test/__snapshots__/config-with-extends.eslint.spec.ts.snap
+++ b/integration_test/__snapshots__/config-with-extends.eslint.spec.ts.snap
@@ -96,6 +96,9 @@ exports[`config-with-extends.eslint.spec.ts --js-plugins > config-with-extends.e
         "files": [
           "**/*.ts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "plugins": [
           "typescript",
         ],
@@ -118,6 +121,8 @@ exports[`config-with-extends.eslint.spec.ts --js-plugins > config-with-extends.e
           "@typescript-eslint/prefer-namespace-keyword": "error",
           "@typescript-eslint/triple-slash-reference": "error",
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-new-symbol": "off",
           "no-array-constructor": "error",
           "no-class-assign": "off",
           "no-const-assign": "off",

--- a/integration_test/__snapshots__/eslint-plugin-oxlint.spec.ts.snap
+++ b/integration_test/__snapshots__/eslint-plugin-oxlint.spec.ts.snap
@@ -286,6 +286,9 @@ exports[`eslint-plugin-oxlint --js-plugins > eslint-plugin-oxlint--js-plugins 1`
     "ignorePatterns": [
       "dist/",
     ],
+    "jsPlugins": [
+      "oxlint-plugin-eslint",
+    ],
     "overrides": [
       {
         "files": [
@@ -294,8 +297,13 @@ exports[`eslint-plugin-oxlint --js-plugins > eslint-plugin-oxlint--js-plugins 1`
           "**/*.mts",
           "**/*.cts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-new-symbol": "off",
           "no-class-assign": "off",
           "no-const-assign": "off",
           "no-dupe-class-members": "off",
@@ -339,6 +347,8 @@ exports[`eslint-plugin-oxlint --js-plugins > eslint-plugin-oxlint--js-plugins 1`
       "@typescript-eslint/prefer-namespace-keyword": "error",
       "@typescript-eslint/triple-slash-reference": "error",
       "constructor-super": "error",
+      "eslint-js/no-dupe-args": "error",
+      "eslint-js/no-octal": "error",
       "for-direction": "error",
       "no-array-constructor": "error",
       "no-async-promise-executor": "error",
@@ -534,8 +544,6 @@ exports[`eslint-plugin-oxlint --js-plugins > eslint-plugin-oxlint--js-plugins 1`
     ],
     "type-aware": [],
     "unsupported": [
-      "no-dupe-args",
-      "no-octal",
       "unicorn/no-for-loop",
       "unicorn/no-named-default",
     ],

--- a/integration_test/__snapshots__/many-extends.spec.ts.snap
+++ b/integration_test/__snapshots__/many-extends.spec.ts.snap
@@ -350,6 +350,9 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
       "builtin": true,
       "es2018": true,
     },
+    "jsPlugins": [
+      "oxlint-plugin-eslint",
+    ],
     "overrides": [
       {
         "env": {
@@ -366,6 +369,9 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
         "files": [
           "**/*.ts",
           "**/*.tsx",
+        ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
         ],
         "plugins": [
           "typescript",
@@ -413,6 +419,11 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
           "@typescript-eslint/triple-slash-reference": "error",
           "@typescript-eslint/unified-signatures": "error",
           "constructor-super": "off",
+          "eslint-js/dot-notation": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-implied-eval": "off",
+          "eslint-js/no-new-symbol": "off",
+          "eslint-js/no-return-await": "off",
           "import/consistent-type-specifier-style": [
             "error",
             "prefer-top-level",
@@ -464,6 +475,8 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
     ],
     "rules": {
       "constructor-super": "error",
+      "eslint-js/no-dupe-args": "error",
+      "eslint-js/no-octal": "error",
       "for-direction": "error",
       "import/default": "error",
       "import/namespace": "error",
@@ -648,8 +661,6 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
       "@typescript-eslint/prefer-nullish-coalescing",
     ],
     "unsupported": [
-      "no-dupe-args",
-      "no-octal",
       "import/no-unresolved",
       "react/jsx-uses-vars",
       "react-hooks/static-components",

--- a/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
+++ b/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
@@ -1062,6 +1062,7 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
     ],
     "jsPlugins": [
       "eslint-plugin-antfu",
+      "oxlint-plugin-eslint",
       "eslint-plugin-unused-imports",
       "eslint-plugin-eslint-comments",
       "eslint-plugin-command",
@@ -1099,6 +1100,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/*.?([cm])ts",
           "**/*.?([cm])tsx",
           "**/*.vue",
+        ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
         ],
         "plugins": [
           "typescript",
@@ -1152,6 +1156,8 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "@typescript-eslint/triple-slash-reference": "off",
           "@typescript-eslint/unified-signatures": "off",
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-new-symbol": "off",
           "no-class-assign": "off",
           "no-const-assign": "off",
           "no-dupe-keys": "off",
@@ -1294,6 +1300,7 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         ],
         "jsPlugins": [
           "eslint-plugin-antfu",
+          "oxlint-plugin-eslint",
           "@stylistic/eslint-plugin",
           "eslint-plugin-unused-imports",
         ],
@@ -1308,6 +1315,7 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "@typescript-eslint/no-namespace": "off",
           "@typescript-eslint/no-require-imports": "off",
           "antfu/no-top-level-await": "off",
+          "eslint-js/no-restricted-syntax": "off",
           "no-alert": "off",
           "no-labels": "off",
           "no-lone-blocks": "off",
@@ -1367,10 +1375,12 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         ],
         "jsPlugins": [
           "eslint-plugin-eslint-comments",
+          "oxlint-plugin-eslint",
           "eslint-plugin-unused-imports",
         ],
         "rules": {
           "eslint-comments/no-unlimited-disable": "off",
+          "eslint-js/no-restricted-syntax": "off",
           "unused-imports/no-unused-vars": "off",
         },
       },
@@ -1810,6 +1820,68 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
       "eslint-comments/no-duplicate-disable": "error",
       "eslint-comments/no-unlimited-disable": "error",
       "eslint-comments/no-unused-enable": "error",
+      "eslint-js/dot-notation": [
+        "error",
+        {
+          "allowKeywords": true,
+        },
+      ],
+      "eslint-js/no-dupe-args": "error",
+      "eslint-js/no-implied-eval": "error",
+      "eslint-js/no-octal": "error",
+      "eslint-js/no-octal-escape": "error",
+      "eslint-js/no-restricted-properties": [
+        "error",
+        {
+          "message": "Use \`Object.getPrototypeOf\` or \`Object.setPrototypeOf\` instead.",
+          "property": "__proto__",
+        },
+        {
+          "message": "Use \`Object.defineProperty\` instead.",
+          "property": "__defineGetter__",
+        },
+        {
+          "message": "Use \`Object.defineProperty\` instead.",
+          "property": "__defineSetter__",
+        },
+        {
+          "message": "Use \`Object.getOwnPropertyDescriptor\` instead.",
+          "property": "__lookupGetter__",
+        },
+        {
+          "message": "Use \`Object.getOwnPropertyDescriptor\` instead.",
+          "property": "__lookupSetter__",
+        },
+      ],
+      "eslint-js/no-restricted-syntax": [
+        "error",
+        "TSEnumDeclaration[const=true]",
+        "TSExportAssignment",
+      ],
+      "eslint-js/no-undef-init": "error",
+      "eslint-js/no-unreachable-loop": "error",
+      "eslint-js/object-shorthand": [
+        "error",
+        "always",
+        {
+          "avoidQuotes": true,
+          "ignoreConstructors": false,
+        },
+      ],
+      "eslint-js/one-var": [
+        "error",
+        {
+          "initialized": "never",
+        },
+      ],
+      "eslint-js/prefer-arrow-callback": [
+        "error",
+        {
+          "allowNamedFunctions": false,
+          "allowUnboundThis": true,
+        },
+      ],
+      "eslint-js/prefer-regex-literals": "error",
       "import/consistent-type-specifier-style": [
         "error",
         "top-level",
@@ -2130,14 +2202,6 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
   "skipped": {
     "js-plugins": [],
     "not-implemented": [
-      "no-implied-eval",
-      "no-restricted-properties",
-      "no-restricted-syntax",
-      "no-unreachable-loop",
-      "object-shorthand",
-      "one-var",
-      "prefer-arrow-callback",
-      "prefer-regex-literals",
       "node/handle-callback-err",
       "node/no-deprecated-api",
       "node/prefer-global/buffer",
@@ -2196,11 +2260,6 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
     ],
     "type-aware": [],
     "unsupported": [
-      "dot-notation",
-      "no-dupe-args",
-      "no-octal",
-      "no-octal-escape",
-      "no-undef-init",
       "vue/comment-directive",
       "vue/no-child-content",
       "vue/no-deprecated-filter",

--- a/integration_test/__snapshots__/pupeeteer.spec.ts.snap
+++ b/integration_test/__snapshots__/pupeeteer.spec.ts.snap
@@ -342,6 +342,7 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
     ],
     "jsPlugins": [
       "eslint-plugin-prettier",
+      "oxlint-plugin-eslint",
       "eslint-plugin-mocha",
       "@stylistic/eslint-plugin",
       "@puppeteer/eslint-plugin",
@@ -352,6 +353,7 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
           "**/*.ts",
         ],
         "jsPlugins": [
+          "oxlint-plugin-eslint",
           "@puppeteer/eslint-plugin",
         ],
         "plugins": [
@@ -403,6 +405,15 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
           "@typescript-eslint/prefer-ts-expect-error": "error",
           "@typescript-eslint/triple-slash-reference": "error",
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-new-symbol": "off",
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "\`require\` statements are not allowed. Use \`import\`.",
+              "selector": "CallExpression[callee.name='require']",
+            },
+          ],
           "no-array-constructor": "error",
           "no-class-assign": "off",
           "no-const-assign": "off",
@@ -435,7 +446,21 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
         "files": [
           "packages/puppeteer-core/src/**/*.ts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Use method \`Deferred.race()\` instead.",
+              "selector": "MemberExpression[object.name="Promise"][property.name="race"]",
+            },
+            {
+              "message": "Deferred \`valueOrThrow\` should not be called in \`Deferred.race()\` pass deferred directly",
+              "selector": "CallExpression[callee.object.name="Deferred"][callee.property.name="race"] > ArrayExpression > CallExpression[callee.property.name="valueOrThrow"]",
+            },
+          ],
           "no-restricted-imports": [
             "error",
             {
@@ -479,6 +504,7 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
           "test/**/*.spec.ts",
         ],
         "jsPlugins": [
+          "oxlint-plugin-eslint",
           "eslint-plugin-mocha",
           "@puppeteer/eslint-plugin",
         ],
@@ -487,6 +513,21 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
         ],
         "rules": {
           "@puppeteer/no-quirks-mode-set-content": "error",
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Use helper command \`launch\` to make sure the browsers get cleaned",
+              "selector": "MemberExpression[object.name="puppeteer"][property.name="launch"]",
+            },
+            {
+              "message": "Unexpected debugging mocha test.",
+              "selector": "CallExpression[callee.object.name="it"] > MemberExpression > Identifier[name="deflake"], CallExpression[callee.object.name="it"] > MemberExpression > Identifier[name="deflakeOnly"]",
+            },
+            {
+              "message": "No \`expect\` in EventHandler. They will never throw errors",
+              "selector": "CallExpression[callee.property.name="on"] BlockStatement > :not(TryStatement) > ExpressionStatement > CallExpression[callee.object.callee.name="expect"]",
+            },
+          ],
           "mocha/no-identical-title": "error",
           "mocha/no-pending-tests": "error",
           "no-unused-vars": [
@@ -527,6 +568,35 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
       "eqeqeq": [
         "error",
       ],
+      "eslint-js/max-len": [
+        "error",
+        {
+          "code": 200,
+          "comments": 90,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
+      "eslint-js/new-parens": "error",
+      "eslint-js/no-implied-eval": "error",
+      "eslint-js/no-new-object": "error",
+      "eslint-js/no-octal-escape": "error",
+      "eslint-js/spaced-comment": [
+        "error",
+        "always",
+        {
+          "markers": [
+            "*",
+            "/",
+          ],
+        },
+      ],
+      "eslint-js/template-curly-spacing": [
+        "error",
+        "never",
+      ],
       "import/no-cycle": [
         "error",
         {
@@ -565,9 +635,7 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
   "skipped": {
     "js-plugins": [],
     "not-implemented": [
-      "no-implied-eval",
       "import/order",
-      "no-restricted-syntax",
     ],
     "nursery": [
       "import/named",
@@ -582,12 +650,6 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
       "@typescript-eslint/return-await",
     ],
     "unsupported": [
-      "spaced-comment",
-      "new-parens",
-      "max-len",
-      "no-new-object",
-      "no-octal-escape",
-      "template-curly-spacing",
       "import/enforce-node-protocol-usage",
     ],
   },

--- a/integration_test/__snapshots__/typescript-simple.spec.ts.snap
+++ b/integration_test/__snapshots__/typescript-simple.spec.ts.snap
@@ -155,6 +155,9 @@ exports[`typescript-simple --js-plugins > typescript-simple--js-plugins 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "plugins": [
           "typescript",
         ],
@@ -189,6 +192,10 @@ exports[`typescript-simple --js-plugins > typescript-simple--js-plugins 1`] = `
           "@typescript-eslint/triple-slash-reference": "error",
           "@typescript-eslint/unified-signatures": "error",
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-implied-eval": "off",
+          "eslint-js/no-new-symbol": "off",
+          "eslint-js/no-return-await": "off",
           "no-array-constructor": "error",
           "no-class-assign": "off",
           "no-const-assign": "off",

--- a/integration_test/__snapshots__/typescript.spec.ts.snap
+++ b/integration_test/__snapshots__/typescript.spec.ts.snap
@@ -424,6 +424,7 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
       "coverage/**",
     ],
     "jsPlugins": [
+      "oxlint-plugin-eslint",
       "eslint-plugin-regexp",
     ],
     "overrides": [
@@ -434,8 +435,13 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
           "**/*.mts",
           "**/*.cts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
           "constructor-super": "off",
+          "eslint-js/no-dupe-args": "off",
+          "eslint-js/no-new-symbol": "off",
           "no-class-assign": "off",
           "no-const-assign": "off",
           "no-dupe-class-members": "off",
@@ -527,11 +533,15 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
         "files": [
           "src/lib/*.d.ts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
           "@typescript-eslint/no-unsafe-function-type": "off",
           "@typescript-eslint/no-wrapper-object-types": "off",
           "@typescript-eslint/prefer-function-type": "off",
           "@typescript-eslint/unified-signatures": "off",
+          "eslint-js/no-restricted-syntax": "off",
           "no-restricted-globals": "off",
           "no-shadow-restricted-names": "off",
           "no-unused-vars": "off",
@@ -572,6 +582,24 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
       "@typescript-eslint/unified-signatures": "error",
       "constructor-super": "error",
       "eqeqeq": "error",
+      "eslint-js/dot-notation": "error",
+      "eslint-js/no-dupe-args": "error",
+      "eslint-js/no-octal": "error",
+      "eslint-js/no-restricted-syntax": [
+        "error",
+        {
+          "message": "Avoid using null; use undefined instead.",
+          "selector": "Literal[raw=null]",
+        },
+        {
+          "message": "Avoid using null; use undefined instead.",
+          "selector": "TSNullKeyword",
+        },
+      ],
+      "eslint-js/no-return-await": "error",
+      "eslint-js/no-undef-init": "error",
+      "eslint-js/object-shorthand": "error",
+      "eslint-js/prefer-regex-literals": "error",
       "for-direction": "error",
       "no-array-constructor": "error",
       "no-async-promise-executor": "error",
@@ -717,9 +745,6 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
   "skipped": {
     "js-plugins": [],
     "not-implemented": [
-      "prefer-regex-literals",
-      "object-shorthand",
-      "no-restricted-syntax",
       "@typescript-eslint/naming-convention",
       "local/only-arrow-functions",
       "local/argument-trivia",
@@ -796,13 +821,7 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
       "@typescript-eslint/unbound-method",
       "@typescript-eslint/use-unknown-in-catch-callback-variable",
     ],
-    "unsupported": [
-      "no-dupe-args",
-      "no-octal",
-      "dot-notation",
-      "no-return-await",
-      "no-undef-init",
-    ],
+    "unsupported": [],
   },
   "warnings": [],
 }

--- a/integration_test/__snapshots__/vscode.spec.ts.snap
+++ b/integration_test/__snapshots__/vscode.spec.ts.snap
@@ -426,6 +426,7 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
       "!.vscode",
     ],
     "jsPlugins": [
+      "oxlint-plugin-eslint",
       "eslint-plugin-header",
     ],
     "overrides": [
@@ -439,6 +440,24 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
         "rules": {
           "@stylistic/ts/member-delimiter-style": "warn",
           "@stylistic/ts/semi": "warn",
+        },
+      },
+      {
+        "files": [
+          "**/vscode.d.ts",
+          "**/vscode.proposed.*.d.ts",
+        ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
+        "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "warn",
+            {
+              "message": "Use Array<...> for arrays of union types.",
+              "selector": "TSArrayType > TSUnionType",
+            },
+          ],
         },
       },
       {
@@ -479,7 +498,153 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
         "files": [
           "src/**/{browser,electron-sandbox}/**/*.ts",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "warn",
+            {
+              "message": "Use DOM.isMouseEvent() to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name='MouseEvent']",
+            },
+            {
+              "message": "Use DOM.isHTMLElement() and related methods to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name=/^HTML\\w+/]",
+            },
+            {
+              "message": "Use DOM.isSVGElement() and related methods to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name=/^SVG\\w+/]",
+            },
+            {
+              "message": "Use DOM.isKeyboardEvent() to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name='KeyboardEvent']",
+            },
+            {
+              "message": "Use DOM.isPointerEvent() to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name='PointerEvent']",
+            },
+            {
+              "message": "Use DOM.isDragEvent() to support multi-window scenarios.",
+              "selector": "BinaryExpression[operator='instanceof'][right.name='DragEvent']",
+            },
+            {
+              "message": "Use <targetWindow>.document.activeElement to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='activeElement']",
+            },
+            {
+              "message": "Use <targetWindow>.document.contains to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='contains']",
+            },
+            {
+              "message": "Use <targetWindow>.document.styleSheets to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='styleSheets']",
+            },
+            {
+              "message": "Use <targetWindow>.document.fullscreenElement to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='fullscreenElement']",
+            },
+            {
+              "message": "Use <targetWindow>.document.body to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='body']",
+            },
+            {
+              "message": "Use <targetWindow>.document.addEventListener to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='addEventListener']",
+            },
+            {
+              "message": "Use <targetWindow>.document.removeEventListener to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='removeEventListener']",
+            },
+            {
+              "message": "Use <targetWindow>.document.hasFocus to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='hasFocus']",
+            },
+            {
+              "message": "Use <targetWindow>.document.head to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='head']",
+            },
+            {
+              "message": "Use <targetWindow>.document.exitFullscreen to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='exitFullscreen']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getElementById to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getElementById']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getElementsByClassName to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getElementsByClassName']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getElementsByName to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getElementsByName']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getElementsByTagName to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getElementsByTagName']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getElementsByTagNameNS to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getElementsByTagNameNS']",
+            },
+            {
+              "message": "Use <targetWindow>.document.getSelection to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='getSelection']",
+            },
+            {
+              "message": "Use <targetWindow>.document.open to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='open']",
+            },
+            {
+              "message": "Use <targetWindow>.document.close to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='close']",
+            },
+            {
+              "message": "Use <targetWindow>.document.documentElement to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='documentElement']",
+            },
+            {
+              "message": "Use <targetWindow>.document.visibilityState to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='visibilityState']",
+            },
+            {
+              "message": "Use <targetWindow>.document.querySelector to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='querySelector']",
+            },
+            {
+              "message": "Use <targetWindow>.document.querySelectorAll to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='querySelectorAll']",
+            },
+            {
+              "message": "Use <targetWindow>.document.elementFromPoint to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='elementFromPoint']",
+            },
+            {
+              "message": "Use <targetWindow>.document.elementsFromPoint to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='elementsFromPoint']",
+            },
+            {
+              "message": "Use <targetWindow>.document.onkeydown to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='onkeydown']",
+            },
+            {
+              "message": "Use <targetWindow>.document.onkeyup to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='onkeyup']",
+            },
+            {
+              "message": "Use <targetWindow>.document.onmousedown to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='onmousedown']",
+            },
+            {
+              "message": "Use <targetWindow>.document.onmouseup to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='onmouseup']",
+            },
+            {
+              "message": "Use <targetWindow>.document.execCommand to support multi-window scenarios. Resolve targetWindow with DOM.getWindow(element) or DOM.getActiveWindow() or use the predefined mainWindow constant.",
+              "selector": "MemberExpression[object.name='document'][property.name='execCommand']",
+            },
+          ],
           "no-restricted-globals": [
             "warn",
             "name",
@@ -664,12 +829,29 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
           ],
         },
       },
+      {
+        "files": [
+          "src/vs/workbench/contrib/terminal/**/*.ts",
+          "src/vs/workbench/contrib/terminalContrib/**/*.ts",
+        ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
+        "rules": {
+          "eslint-js/comma-dangle": [
+            "warn",
+            "only-multiline",
+          ],
+        },
+      },
     ],
     "plugins": [],
     "rules": {
       "constructor-super": "warn",
       "curly": "warn",
       "eqeqeq": "warn",
+      "eslint-js/no-buffer-constructor": "warn",
+      "eslint-js/no-extra-semi": "warn",
       "header/header": [
         "error",
         "block",
@@ -736,7 +918,6 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
       "local/code-no-test-async-suite",
       "local/code-must-use-result",
       "local/code-ensure-no-disposables-leak-in-test",
-      "no-restricted-syntax",
       "local/vscode-dts-create-func",
       "local/vscode-dts-literal-or-types",
       "local/vscode-dts-string-type-literals",
@@ -761,11 +942,7 @@ exports[`vscode --js-plugins > vscode--js-plugins 1`] = `
       "@typescript-eslint/prefer-readonly",
     ],
     "type-aware": [],
-    "unsupported": [
-      "no-buffer-constructor",
-      "no-extra-semi",
-      "comma-dangle",
-    ],
+    "unsupported": [],
   },
   "warnings": [],
 }

--- a/integration_test/__snapshots__/vuejs-core.spec.ts.snap
+++ b/integration_test/__snapshots__/vuejs-core.spec.ts.snap
@@ -376,6 +376,9 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
           "**/*.ts",
           "**/*.tsx",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "plugins": [
           "import",
           "typescript",
@@ -390,6 +393,30 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
           ],
           "@typescript-eslint/no-import-type-side-effects": "error",
           "@typescript-eslint/prefer-ts-expect-error": "error",
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Please use non-const enums. This project automatically inlines enums.",
+              "selector": "TSEnumDeclaration[const=true]",
+            },
+            {
+              "message": "Our output target is ES2016, and object rest spread results in verbose helpers and should be avoided.",
+              "selector": "ObjectPattern > RestElement",
+            },
+            {
+              "message": "esbuild transpiles object spread into very verbose inline helpers.
+Please use the \`extend\` helper from @vue/shared instead.",
+              "selector": "ObjectExpression > SpreadElement",
+            },
+            {
+              "message": "Our output target is ES2016, so async/await syntax should be avoided.",
+              "selector": "AwaitExpression",
+            },
+            {
+              "message": "Our output target is ES2016, and optional chaining results in verbose helpers and should be avoided.",
+              "selector": "ChainExpression",
+            },
+          ],
           "import-x/no-nodejs-modules": [
             "error",
             {
@@ -516,10 +543,14 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
           "vi": "writable",
           "vitest": "writable",
         },
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "plugins": [
           "vitest",
         ],
         "rules": {
+          "eslint-js/no-restricted-syntax": "off",
           "no-console": "off",
           "no-restricted-globals": "off",
           "vitest/no-disabled-tests": "error",
@@ -551,7 +582,17 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
         "files": [
           "packages/{compiler-sfc,compiler-ssr,server-renderer}/**",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Please use non-const enums. This project automatically inlines enums.",
+              "selector": "TSEnumDeclaration[const=true]",
+            },
+          ],
           "no-restricted-globals": [
             "error",
             "window",
@@ -564,7 +605,17 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
           "packages-private/template-explorer/**",
           "packages-private/sfc-playground/**",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Please use non-const enums. This project automatically inlines enums.",
+              "selector": "TSEnumDeclaration[const=true]",
+            },
+          ],
           "no-console": "off",
           "no-restricted-globals": [
             "error",
@@ -596,7 +647,17 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
           "packages/*/*.js",
           "packages/vue/*/*.js",
         ],
+        "jsPlugins": [
+          "oxlint-plugin-eslint",
+        ],
         "rules": {
+          "eslint-js/no-restricted-syntax": [
+            "error",
+            {
+              "message": "Please use non-const enums. This project automatically inlines enums.",
+              "selector": "TSEnumDeclaration[const=true]",
+            },
+          ],
           "no-console": "off",
           "no-restricted-globals": "off",
         },
@@ -691,9 +752,7 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
   },
   "skipped": {
     "js-plugins": [],
-    "not-implemented": [
-      "no-restricted-syntax",
-    ],
+    "not-implemented": [],
     "nursery": [],
     "type-aware": [],
     "unsupported": [],

--- a/integration_test/e2e/js-plugins-core-eslint-rules.spec.ts
+++ b/integration_test/e2e/js-plugins-core-eslint-rules.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import migrateConfig from '../../src/index.js';
+
+import type { Linter } from 'eslint';
+
+// ESLint config with an unsupported core rule enabled in base, disabled in override.
+const firstEslintConfig: Linter.Config[] = [
+  {
+    rules: {
+      'no-restricted-syntax': ['error', 'WithStatement'],
+    },
+  },
+  {
+    files: ['**/*.test.js'],
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
+  },
+];
+
+// ESLint config with an unsupported core rule disabled in base, enabled in override.
+const secondEslintConfig: Linter.Config[] = [
+  {
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
+  },
+  {
+    files: ['**/*.test.js'],
+    rules: {
+      'no-restricted-syntax': ['error', 'WithStatement'],
+    },
+  },
+];
+
+describe('JS Plugins with core ESLint rules', () => {
+  test('core rule enabled in base, disabled in override', async () => {
+    const oxlintConfig = await migrateConfig(firstEslintConfig, undefined, {
+      jsPlugins: true,
+    });
+
+    expect(
+      oxlintConfig.rules?.['eslint-js/no-restricted-syntax']
+    ).toStrictEqual(['error', 'WithStatement']);
+    expect(oxlintConfig.rules?.['no-restricted-syntax']).toBeUndefined();
+    expect(oxlintConfig.jsPlugins).toStrictEqual(['oxlint-plugin-eslint']);
+
+    const overrides = oxlintConfig.overrides!;
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].rules?.['eslint-js/no-restricted-syntax']).toBe('off');
+    expect(overrides[0].rules?.['no-restricted-syntax']).toBeUndefined();
+  });
+
+  test('core rule disabled in base, enabled in override', async () => {
+    const oxlintConfig = await migrateConfig(secondEslintConfig, undefined, {
+      jsPlugins: true,
+    });
+
+    expect(
+      oxlintConfig.rules?.['eslint-js/no-restricted-syntax']
+    ).toBeUndefined();
+    expect(oxlintConfig.rules?.['no-restricted-syntax']).toBeUndefined();
+    expect(oxlintConfig.jsPlugins).toBeUndefined();
+
+    const overrides = oxlintConfig.overrides!;
+    expect(overrides).toHaveLength(1);
+    expect(overrides[0].jsPlugins).toStrictEqual(['oxlint-plugin-eslint']);
+    expect(
+      overrides[0].rules?.['eslint-js/no-restricted-syntax']
+    ).toStrictEqual(['error', 'WithStatement']);
+  });
+});

--- a/src/jsPlugins.ts
+++ b/src/jsPlugins.ts
@@ -18,6 +18,9 @@ const guessEslintPluginName = (pluginName: string): string => {
     // Plain scoped plugin (e.g. @stylistic)
     return `${scope}/eslint-plugin`;
   }
+
+  if (pluginName === 'eslint-js') return 'oxlint-plugin-eslint';
+
   return `eslint-plugin-${pluginName}`;
 };
 

--- a/src/plugin_rules.spec.ts
+++ b/src/plugin_rules.spec.ts
@@ -535,6 +535,110 @@ describe('rules and plugins', () => {
       // rule should also be removed from overrides
       expect(overrides[0].rules?.['some-plugin/some-rule']).toBeUndefined();
     });
+
+    test('active unsupported core rule is mapped to eslint-js/ prefix', () => {
+      const eslintConfig: Linter.Config = {
+        rules: {
+          'no-restricted-syntax': ['error', 'WithStatement'],
+        },
+      };
+
+      const config: OxlintConfig = {};
+
+      transformRuleEntry(eslintConfig, config, undefined, {
+        jsPlugins: true,
+      });
+
+      expect(config.rules?.['eslint-js/no-restricted-syntax']).toStrictEqual([
+        'error',
+        'WithStatement',
+      ]);
+      expect(config.rules?.['no-restricted-syntax']).toBeUndefined();
+      expect(config.jsPlugins).toContainEqual('oxlint-plugin-eslint');
+    });
+
+    test('off core rule in base config deletes eslint-js/ prefixed key', () => {
+      const enablingConfig: Linter.Config = {
+        rules: {
+          'no-restricted-syntax': ['error', 'WithStatement'],
+        },
+      };
+
+      const disablingConfig: Linter.Config = {
+        rules: {
+          'no-restricted-syntax': 'off',
+        },
+      };
+
+      const config: OxlintConfig = {};
+
+      transformRuleEntry(enablingConfig, config, undefined, {
+        jsPlugins: true,
+      });
+      transformRuleEntry(disablingConfig, config, undefined, {
+        jsPlugins: true,
+      });
+
+      expect(config.rules?.['eslint-js/no-restricted-syntax']).toBeUndefined();
+      expect(config.rules?.['no-restricted-syntax']).toBeUndefined();
+    });
+
+    test('off core rule in override is kept with eslint-js/ prefix', () => {
+      const eslintConfig: Linter.Config = {
+        files: ['**/*.test.js'],
+        rules: {
+          'no-restricted-syntax': 'off',
+        },
+      };
+
+      const override: OxlintConfigOverride = { files: ['**/*.test.js'] };
+
+      transformRuleEntry(eslintConfig, override, undefined, {
+        jsPlugins: true,
+      });
+
+      expect(override.rules?.['eslint-js/no-restricted-syntax']).toBe('off');
+      expect(override.rules?.['no-restricted-syntax']).toBeUndefined();
+    });
+
+    test('base config removes eslint-js/ prefixed core rule from earlier override', () => {
+      const overrideConfig: Linter.Config = {
+        files: ['**/*.js'],
+        rules: {
+          'no-restricted-syntax': ['error', 'WithStatement'],
+        },
+      };
+
+      const baseConfig: Linter.Config = {
+        rules: {
+          'no-restricted-syntax': ['error', 'ForInStatement'],
+        },
+      };
+
+      const overrides: OxlintConfigOverride[] = [{ files: ['**/*.js'] }];
+      const baseTarget: OxlintConfig = {};
+
+      transformRuleEntry(overrideConfig, overrides[0], undefined, {
+        jsPlugins: true,
+      });
+      transformRuleEntry(
+        baseConfig,
+        baseTarget,
+        undefined,
+        { jsPlugins: true },
+        overrides
+      );
+
+      // Base config wins: override's rule is removed
+      expect(
+        overrides[0].rules?.['eslint-js/no-restricted-syntax']
+      ).toBeUndefined();
+      // Base config has the rule with new value
+      expect(
+        baseTarget.rules?.['eslint-js/no-restricted-syntax']
+      ).toStrictEqual(['error', 'ForInStatement']);
+      expect(baseTarget.jsPlugins).toContainEqual('oxlint-plugin-eslint');
+    });
   });
 
   test('cleanUpUselessOverridesRules', () => {

--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -3,6 +3,7 @@ import * as rules from './generated/rules.js';
 import {
   Options,
   OxlintConfig,
+  OxlintConfigJsPluginEntry,
   OxlintConfigOrOverride,
   OxlintConfigOverride,
   type Category,
@@ -172,8 +173,16 @@ export const transformRuleEntry = (
     targetConfig.rules = {};
   }
 
-  for (const [rule, config] of Object.entries(eslintConfig.rules)) {
+  for (let [rule, config] of Object.entries(eslintConfig.rules)) {
     const normalizedConfig = normalizeSeverityValue(config);
+
+    const isSupported = allRules.includes(rule);
+
+    // When --js-plugins is enabled, rename unsupported core ESLint rules to
+    // `eslint-js/<rule>` so they flow through the JS plugin path naturally.
+    if (!isSupported && options?.jsPlugins && !rule.includes('/')) {
+      rule = `eslint-js/${rule}`;
+    }
 
     // removing rules from previous "overrides"
     // only works on non-merge because `overrides` is already prefilled from previous result.
@@ -181,7 +190,7 @@ export const transformRuleEntry = (
       removePreviousOverrideRule(rule, eslintConfig, overrides);
     }
 
-    if (allRules.includes(rule)) {
+    if (isSupported) {
       if (!options?.withNursery && rules.nurseryRules.includes(rule)) {
         options?.reporter?.markSkipped(rule, 'nursery');
         continue;


### PR DESCRIPTION
WIP. This branch has got well behind main and I'm struggling to resolve the conflicts. It seems some significant changes happened since I (by which I mean Claude) originally wrote this.

But [oxlint-plugin-eslint](https://www.npmjs.com/package/oxlint-plugin-eslint) package has now been published, and it is going to be our recommended way to use built-in ESLint rules which Oxc doesn't support natively. So we probably should make this change.