### PR TITLE
docs: map npm package links to npmx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # @oxlint/migrate
 
 ![test](https://github.com/oxc-project/oxlint-migrate/actions/workflows/test.yml/badge.svg)
-[![NPM Version](https://img.shields.io/npm/v/%40oxlint%2Fmigrate)](https://www.npmjs.com/package/@oxlint/migrate)
-[![NPM Downloads](https://img.shields.io/npm/dm/%40oxlint%2Fmigrate)](https://www.npmjs.com/package/@oxlint/migrate)
+[![NPM Version](https://img.shields.io/npm/v/%40oxlint%2Fmigrate)](https://npmx.dev/package/@oxlint/migrate)
+[![NPM Downloads](https://img.shields.io/npm/dm/%40oxlint%2Fmigrate)](https://npmx.dev/package/@oxlint/migrate)
 
 Generates a `.oxlintrc.json` from an existing ESLint flat config.
 
@@ -49,7 +49,7 @@ TypeScript configuration files, like `eslint.config.mts`, are supported in the f
 - **Deno and Bun**: TypeScript configuration files are natively supported.
 - **Node.js >=22.18.0**: TypeScript configuration files are supported natively with built-in type-stripping enabled by default.
 - **Node.js >=22.6.0**: TypeScript configuration files can be used by setting `NODE_OPTIONS=--experimental-strip-types`.
-- **Node.js <22.6.0**: TypeScript configuration files can be used by setting `NODE_OPTIONS=--import @oxc-node/core/register` and installing [@oxc-node/core](https://www.npmjs.com/package/@oxc-node/core) as a dev dependency.
+- **Node.js <22.6.0**: TypeScript configuration files can be used by setting `NODE_OPTIONS=--import @oxc-node/core/register` and installing [@oxc-node/core](https://npmx.dev/package/@oxc-node/core) as a dev dependency.
 
 If you attempt to use a TypeScript configuration file without the proper setup for your Node.js version, Node.js will throw an error when trying to import the file.
 


### PR DESCRIPTION
## Summary
- replace npm package links from npmjs.com to https://npmx.dev
- only update documentation files