### PR TITLE
chore: Improve warning messages for unsupported settings

### DIFF
--- a/bin/output-formatter.spec.ts
+++ b/bin/output-formatter.spec.ts
@@ -3,6 +3,7 @@ import {
   formatCategorySummary,
   detectMissingFlags,
   formatMigrationOutput,
+  formatWarningsOutput,
   type MigrationOutputData,
 } from './output-formatter.js';
 import { SkippedCategoryGroup } from '../src/types.js';
@@ -217,6 +218,33 @@ describe('detectMissingFlags', () => {
     const result = detectMissingFlags(byCategory, cliOptions);
 
     expect(result).toEqual([]);
+  });
+});
+
+describe('formatWarningsOutput', () => {
+  it('should return empty string when no warnings', () => {
+    expect(formatWarningsOutput([])).toBe('');
+  });
+
+  it('should format single-line warnings as bullets', () => {
+    const result = formatWarningsOutput(['first warning', 'second warning']);
+
+    expect(result).toBe(
+      '⚠️  Warnings (2):\n' + '   * first warning\n' + '   * second warning'
+    );
+  });
+
+  it('should format multiline warnings with sub-bullets', () => {
+    const result = formatWarningsOutput([
+      'Settings not migrated (not supported by oxlint):\n`import/resolver`\n`custom-plugin`',
+    ]);
+
+    expect(result).toBe(
+      '⚠️  Warnings (1):\n' +
+        '   * Settings not migrated (not supported by oxlint):\n' +
+        '     * `import/resolver`\n' +
+        '     * `custom-plugin`'
+    );
   });
 });
 

--- a/bin/output-formatter.ts
+++ b/bin/output-formatter.ts
@@ -209,13 +209,32 @@ export function formatMigrationOutput(data: MigrationOutputData): string {
   return output;
 }
 
+export function formatWarningsOutput(warnings: string[]): string {
+  if (warnings.length === 0) {
+    return '';
+  }
+
+  let output = `⚠️  Warnings (${warnings.length}):\n`;
+
+  for (const warning of warnings) {
+    const [message, ...details] = warning.split('\n');
+    output += `   * ${message}\n`;
+
+    for (const detail of details.filter((line) => line.trim().length)) {
+      output += `     * ${detail}\n`;
+    }
+  }
+
+  return output.trimEnd();
+}
+
 export function displayMigrationResult(
   outputMessage: string,
   warnings: string[]
 ): void {
   console.log(outputMessage);
 
-  for (const warning of warnings) {
-    console.warn(warning);
+  if (warnings.length > 0) {
+    console.warn(formatWarningsOutput(warnings));
   }
 }

--- a/integration_test/__snapshots__/eslint-react.spec.ts.snap
+++ b/integration_test/__snapshots__/eslint-react.spec.ts.snap
@@ -187,7 +187,8 @@ exports[`eslint-react > eslint-react 1`] = `
     ],
   },
   "warnings": [
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -386,7 +387,8 @@ exports[`eslint-react --js-plugins > eslint-react--js-plugins 1`] = `
     ],
   },
   "warnings": [
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -578,7 +580,8 @@ exports[`eslint-react --type-aware > eslint-react--type-aware 1`] = `
     ],
   },
   "warnings": [
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -770,7 +773,8 @@ exports[`eslint-react merge > eslint-react--merge 1`] = `
     ],
   },
   "warnings": [
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/many-extends.spec.ts.snap
+++ b/integration_test/__snapshots__/many-extends.spec.ts.snap
@@ -332,9 +332,15 @@ exports[`many-extends.spec.ts > many-extends.spec.ts 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions.",
-    "Settings found in config with 'files' pattern (import/extensions). Oxlint does not support settings in overrides, these settings will be skipped.",
-    "Settings found in config with 'files' pattern (import/extensions, import/external-module-folders, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -671,9 +677,15 @@ exports[`many-extends.spec.ts --js-plugins > many-extends.spec.ts--js-plugins 1`
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions.",
-    "Settings found in config with 'files' pattern (import/extensions). Oxlint does not support settings in overrides, these settings will be skipped.",
-    "Settings found in config with 'files' pattern (import/extensions, import/external-module-folders, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -1031,9 +1043,15 @@ exports[`many-extends.spec.ts --type-aware > many-extends.spec.ts--type-aware 1`
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions.",
-    "Settings found in config with 'files' pattern (import/extensions). Oxlint does not support settings in overrides, these settings will be skipped.",
-    "Settings found in config with 'files' pattern (import/extensions, import/external-module-folders, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -1324,9 +1342,15 @@ exports[`many-extends.spec.ts merge > many-extends.spec.ts--merge 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions.",
-    "Settings found in config with 'files' pattern (import/extensions). Oxlint does not support settings in overrides, these settings will be skipped.",
-    "Settings found in config with 'files' pattern (import/extensions, import/external-module-folders, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/next-core-web-vitals.spec.ts.snap
+++ b/integration_test/__snapshots__/next-core-web-vitals.spec.ts.snap
@@ -137,7 +137,10 @@ exports[`next-core-web-vitals > next-core-web-vitals 1`] = `
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -279,7 +282,10 @@ exports[`next-core-web-vitals --js-plugins > next-core-web-vitals--js-plugins 1`
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -421,7 +427,10 @@ exports[`next-core-web-vitals --type-aware > next-core-web-vitals--type-aware 1`
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -564,7 +573,10 @@ exports[`next-core-web-vitals merge > next-core-web-vitals--merge 1`] = `
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/next-eslint-config-project.spec.ts.snap
+++ b/integration_test/__snapshots__/next-eslint-config-project.spec.ts.snap
@@ -135,7 +135,10 @@ exports[`next-eslint-config-project > next-eslint-config-project 1`] = `
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -275,7 +278,10 @@ exports[`next-eslint-config-project --js-plugins > next-eslint-config-project--j
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -415,7 +421,10 @@ exports[`next-eslint-config-project --type-aware > next-eslint-config-project--t
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;
@@ -556,7 +565,10 @@ exports[`next-eslint-config-project merge > next-eslint-config-project--merge 1`
   },
   "warnings": [
     "special parser detected: eslint-config-next/parser",
-    "Settings found in config with 'files' pattern (react, import/parsers, import/resolver). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react\`
+\`import/parsers\`
+\`import/resolver\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/pupeeteer.spec.ts.snap
+++ b/integration_test/__snapshots__/pupeeteer.spec.ts.snap
@@ -282,8 +282,13 @@ exports[`puppeteer > puppeteer 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions, import/external-module-folders, import/parsers, import/resolver.",
-    "Settings not migrated (not supported by oxlint): import/resolver.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`",
   ],
 }
 `;
@@ -592,8 +597,13 @@ exports[`puppeteer --js-plugins > puppeteer--js-plugins 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions, import/external-module-folders, import/parsers, import/resolver.",
-    "Settings not migrated (not supported by oxlint): import/resolver.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`",
   ],
 }
 `;
@@ -900,8 +910,13 @@ exports[`puppeteer --type-aware > puppeteer--type-aware 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions, import/external-module-folders, import/parsers, import/resolver.",
-    "Settings not migrated (not supported by oxlint): import/resolver.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`",
   ],
 }
 `;
@@ -1170,8 +1185,13 @@ exports[`puppeteer merge > puppeteer--merge 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/extensions, import/external-module-folders, import/parsers, import/resolver.",
-    "Settings not migrated (not supported by oxlint): import/resolver.",
+    "Settings not migrated (not supported by oxlint):
+\`import/extensions\`
+\`import/external-module-folders\`
+\`import/parsers\`
+\`import/resolver\`",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/react-web-api.spec.ts.snap
+++ b/integration_test/__snapshots__/react-web-api.spec.ts.snap
@@ -123,7 +123,8 @@ exports[`react-web-api > react-web-api 1`] = `
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.tsx"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.mts"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.cts"]",
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -253,7 +254,8 @@ exports[`react-web-api --js-plugins > react-web-api--js-plugins 1`] = `
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.tsx"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.mts"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.cts"]",
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -381,7 +383,8 @@ exports[`react-web-api --type-aware > react-web-api--type-aware 1`] = `
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.tsx"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.mts"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.cts"]",
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;
@@ -509,7 +512,8 @@ exports[`react-web-api merge > react-web-api--merge 1`] = `
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.tsx"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.mts"]",
     "ESLint AND glob patterns (nested arrays in files) are not supported in oxlint: ["**/*.{ts,tsx}","**/*.cts"]",
-    "Settings found in config with 'files' pattern (react-x). Oxlint does not support settings in overrides, these settings will be skipped.",
+    "Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
+\`react-x\`",
   ],
 }
 `;

--- a/integration_test/__snapshots__/settings-migration.spec.ts.snap
+++ b/integration_test/__snapshots__/settings-migration.spec.ts.snap
@@ -63,7 +63,9 @@ exports[`settings-migration > settings-migration 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/resolver, my-custom-plugin.",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`
+\`my-custom-plugin\`",
   ],
 }
 `;
@@ -134,7 +136,8 @@ exports[`settings-migration --js-plugins > settings-migration--js-plugins 1`] = 
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/resolver.",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`",
   ],
 }
 `;
@@ -202,7 +205,9 @@ exports[`settings-migration --type-aware > settings-migration--type-aware 1`] = 
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/resolver, my-custom-plugin.",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`
+\`my-custom-plugin\`",
   ],
 }
 `;
@@ -271,7 +276,9 @@ exports[`settings-migration merge > settings-migration--merge 1`] = `
     ],
   },
   "warnings": [
-    "Settings not migrated (not supported by oxlint): import/resolver, my-custom-plugin.",
+    "Settings not migrated (not supported by oxlint):
+\`import/resolver\`
+\`my-custom-plugin\`",
   ],
 }
 `;

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -337,9 +337,11 @@ describe('transformSettings', () => {
       });
       const warnings = reporter.getWarnings();
       expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain('import/resolver');
-      expect(warnings[0]).toContain('custom-plugin');
-      expect(warnings[0]).toContain('not supported by oxlint');
+      expect(warnings[0]).toContain(
+        'Settings not migrated (not supported by oxlint):'
+      );
+      expect(warnings[0]).toContain('\n`import/resolver`');
+      expect(warnings[0]).toContain('\n`custom-plugin`');
     });
 
     it('should skip non-object settings values', () => {
@@ -360,8 +362,11 @@ describe('transformSettings', () => {
       });
       const warnings = reporter.getWarnings();
       expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain('string-setting');
-      expect(warnings[0]).toContain('number-setting');
+      expect(warnings[0]).toContain(
+        'Settings not migrated (not supported by oxlint):'
+      );
+      expect(warnings[0]).toContain('\n`string-setting`');
+      expect(warnings[0]).toContain('\n`number-setting`');
     });
   });
 
@@ -392,7 +397,7 @@ describe('transformSettings', () => {
       // Should still warn about unsupported settings
       const warnings = reporter.getWarnings();
       expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain('import/resolver');
+      expect(warnings[0]).toContain('\n`import/resolver`');
     });
   });
 
@@ -503,9 +508,10 @@ describe('warnSettingsInOverride', () => {
 
     const warnings = reporter.getWarnings();
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('react');
-    expect(warnings[0]).toContain('jsx-a11y');
+    expect(warnings[0]).toContain("Settings found under a 'files' pattern");
     expect(warnings[0]).toContain('does not support settings in overrides');
+    expect(warnings[0]).toContain('\n`react`');
+    expect(warnings[0]).toContain('\n`jsx-a11y`');
   });
 
   it('should not warn when no settings in override config', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,14 @@ const isSupportedSettingsKey = (key: OxlintSupportedSettingsKey): boolean => {
 };
 
 /**
+ * Format a list of settings keys into a newline-separated, backtick-quoted
+ * string for warning output.
+ */
+const formatSettingsKeyList = (keys: string[]): string => {
+  return keys.map((key) => `\`${key}\``).join('\n');
+};
+
+/**
  * Transform ESLint settings to oxlint settings.
  *
  * Only processes settings for the base config (not overrides) since oxlint
@@ -116,8 +124,8 @@ export const transformSettings = (
     // Special case: react.version = "detect" is not supported by oxlint
     if (key === 'react' && settingsValue.version === 'detect') {
       options?.reporter?.addWarning(
-        `react.version "detect" is not supported by oxlint. ` +
-          `Please specify an explicit version (e.g., "18.2.0") in your oxlint config.`
+        `react.version "detect" is not supported. ` +
+          `Specify an explicit version (e.g., "18.2.0") in your oxlint config.`
       );
       const { version: _, ...restReactSettings } = settingsValue;
       settingsValue = restReactSettings;
@@ -127,18 +135,12 @@ export const transformSettings = (
     // or `vitest.vitestImports`, and warn about them.
     const unsupportedSubKeys = UNSUPPORTED_SETTINGS_SUB_KEYS[key];
     if (unsupportedSubKeys !== undefined) {
-      const strippedKeys: string[] = [];
       for (const subKey of unsupportedSubKeys) {
         if (subKey in settingsValue) {
-          strippedKeys.push(`${key}.${subKey}`);
+          skippedKeys.push(`${key}.${subKey}`);
           const { [subKey]: _, ...rest } = settingsValue;
           settingsValue = rest;
         }
-      }
-      if (strippedKeys.length > 0) {
-        options?.reporter?.addWarning(
-          `Settings not migrated (not supported by oxlint): ${strippedKeys.join(', ')}.`
-        );
       }
     }
 
@@ -153,7 +155,7 @@ export const transformSettings = (
   // Warn about unsupported settings that were skipped
   if (skippedKeys.length > 0) {
     options?.reporter?.addWarning(
-      `Settings not migrated (not supported by oxlint): ${skippedKeys.join(', ')}.`
+      `Settings not migrated (not supported by oxlint):\n${formatSettingsKeyList(skippedKeys)}`
     );
   }
 
@@ -193,10 +195,11 @@ export const warnSettingsInOverride = (
     eslintConfig.settings !== null &&
     Object.keys(eslintConfig.settings).length > 0
   ) {
-    const settingsKeys = Object.keys(eslintConfig.settings).join(', ');
+    const settingsKeys = Object.keys(eslintConfig.settings);
     options?.reporter?.addWarning(
-      `Settings found in config with 'files' pattern (${settingsKeys}). ` +
-        `Oxlint does not support settings in overrides, these settings will be skipped.`
+      `Settings found under a 'files' pattern — ` +
+        `oxlint does not support settings in overrides and they will be skipped:\n` +
+        formatSettingsKeyList(settingsKeys)
     );
   }
 };


### PR DESCRIPTION
## Summary

This PR closes https://github.com/oxc-project/oxlint-migrate/issues/411.

It improves migration's warning output by grouping warnings into a single `⚠️ Warnings (N)` block with some bullets and sub-bullets for readability.

Currently, the string-based reporter is used as is, with `src/settings.ts` returning a multi-line warning message (including a list of keys) and `bin/output-formatter.ts` provides the formatting.

(`skippedKeys` and `strippedKeys` have been merged, and the number of keys is rendered as sub-bullets regardless of whether there is one or more.)

Please let me know if there any feedback on my approach or the changes.

## Changes

| Before | After |
| ------ | ----- |
| <img width="1730" height="1012" alt="CleanShot 2026-03-02 at 00 50 43@2x" src="https://github.com/user-attachments/assets/2bb33d69-17ca-4156-959f-af4c937fc097" /> | <img width="1730" height="1012" alt="CleanShot 2026-03-02 at 00 51 06@2x" src="https://github.com/user-attachments/assets/c9160a34-2a1d-45db-8e55-a3fb8c95214a" /> |

### Before

```sh
npx @oxlint/migrate --type-aware --with-nursery

✨ .oxlintrc.json created with 1 rules.

🚀 Next:
     npx oxlint .

react.version "detect" is not supported by oxlint. Please specify an explicit version (e.g., "18.2.0") in your oxlint config.
Settings not migrated (not supported by oxlint): import/resolver.
Settings found in config with 'files' pattern (import/foo). Oxlint does not support settings in overrides, these settings will be skipped.
```

### After

```sh
npx @oxlint/migrate --type-aware --with-nursery

✨ .oxlintrc.json created with 1 rules.

🚀 Next:
     npx oxlint .

⚠️  Warnings (3):
   * react.version "detect" is not supported. Specify an explicit version (e.g., "18.2.0") in your oxlint config.
   * Settings not migrated (not supported by oxlint):
     * `import/resolver`
   * Settings found under a 'files' pattern — oxlint does not support settings in overrides and they will be skipped:
     * `import/foo`
```