### PR TITLE
chore: migrate oxlint CLI type flags to config options

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,5 +9,9 @@
     "no-unused-expressions": ["error", { "allowShortCircuit": true }],
     "eqeqeq": ["error", "always"],
     "@typescript-eslint/no-array-delete": "off" // FIXME
+  },
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "generate:unsupported": "node --import @oxc-node/core/register ./scripts/fetch-unsupported-rules.ts",
     "generate:all": "pnpm generate:vitest && pnpm generate && pnpm generate:unsupported && pnpm format",
     "format": "oxfmt",
-    "lint": "oxlint --type-aware --type-check",
+    "lint": "oxlint",
     "test": "vitest",
     "build": "tsdown",
     "manual-test": "pnpm build; chmod +x dist/bin/oxlint-migrate.mjs; npx ."


### PR DESCRIPTION
resolves #421 

> ## Summary
> 
>  * upgrade oxlint to latest
>  * migrate `--type-aware` / `--type-check` from CLI usage to `oxlint` config `options`
>  * ~refresh lockfiles/config as needed~
> 
> 
> ## Context
> 
> Aligned with the oxlint options migration introduced in [oxc-project/oxc#19923](https://github.com/oxc-project/oxc/pull/19923).

