### PR TITLE
fix: keep `jsPlugins` entry for `off` rules in overrides

### DIFF
--- a/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
+++ b/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
@@ -1227,6 +1227,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/*.bench.?([cm])[jt]s?(x)",
           "**/*.benchmark.?([cm])[jt]s?(x)",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+        ],
         "plugins": [
           "vitest",
           "typescript",
@@ -1252,6 +1255,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         "files": [
           "**/*.vue",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+        ],
         "plugins": [
           "vue",
           "typescript",
@@ -1275,6 +1281,7 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/*.toml",
         ],
         "jsPlugins": [
+          "@stylistic/eslint-plugin",
           "eslint-plugin-toml",
         ],
         "rules": {
@@ -1309,6 +1316,10 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         ],
         "jsPlugins": [
           "@eslint/eslint-plugin-markdown",
+          "eslint-plugin-command",
+          "eslint-plugin-perfectionist",
+          "eslint-plugin-regexp",
+          "@stylistic/eslint-plugin",
         ],
         "rules": {
           "@stylistic/indent": "off",
@@ -1344,6 +1355,11 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/*.md/**/*.?([cm])[jt]s?(x)",
           "**/*.md/**/*.vue",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+          "@stylistic/eslint-plugin",
+          "eslint-plugin-unused-imports",
+        ],
         "plugins": [
           "typescript",
         ],
@@ -1372,6 +1388,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         "files": [
           "**/scripts/**/*.?([cm])[jt]s?(x)",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+        ],
         "plugins": [
           "typescript",
         ],
@@ -1385,6 +1404,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/cli/**/*.?([cm])[jt]s?(x)",
           "**/cli.?([cm])[jt]s?(x)",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+        ],
         "rules": {
           "antfu/no-top-level-await": "off",
         },
@@ -1394,6 +1416,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "**/bin/**/*",
           "**/bin.?([cm])[jt]s?(x)",
         ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
+        ],
         "rules": {
           "antfu/no-import-dist": "off",
           "antfu/no-import-node-modules-by-path": "off",
@@ -1402,6 +1427,10 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
       {
         "files": [
           "**/*.d.?([cm])ts",
+        ],
+        "jsPlugins": [
+          "eslint-plugin-eslint-comments",
+          "eslint-plugin-unused-imports",
         ],
         "rules": {
           "eslint-comments/no-unlimited-disable": "off",
@@ -1424,6 +1453,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
         "files": [
           "**/*.config.?([cm])[jt]s?(x)",
           "**/*.config.*.?([cm])[jt]s?(x)",
+        ],
+        "jsPlugins": [
+          "eslint-plugin-antfu",
         ],
         "plugins": [
           "typescript",

--- a/integration_test/__snapshots__/overriding-config-merge-with-files.spec.ts.snap
+++ b/integration_test/__snapshots__/overriding-config-merge-with-files.spec.ts.snap
@@ -43,6 +43,9 @@ exports[`overriding-config-merge-with-files --js-plugins > overriding-config-mer
         "files": [
           "**/*.js",
         ],
+        "jsPlugins": [
+          "eslint-plugin-regexp",
+        ],
         "rules": {
           "regexp/no-lazy-ends": [
             "off",

--- a/integration_test/__snapshots__/typescript.spec.ts.snap
+++ b/integration_test/__snapshots__/typescript.spec.ts.snap
@@ -518,6 +518,9 @@ exports[`typescript --js-plugins > typescript--js-plugins 1`] = `
           "src/harness/**",
           "src/testRunner/**",
         ],
+        "jsPlugins": [
+          "eslint-plugin-regexp",
+        ],
         "rules": {
           "no-restricted-globals": "off",
           "regexp/no-super-linear-backtracking": "off",

--- a/integration_test/e2e/js-plugins-with-overrides.spec.ts
+++ b/integration_test/e2e/js-plugins-with-overrides.spec.ts
@@ -55,8 +55,9 @@ describe('JS Plugins with overrides', () => {
     // The override should still be present, should only have one.
     const overrides = oxlintConfig.overrides!;
     expect(overrides).toHaveLength(1);
-    // jsPlugins is unnecessary in the override since it's already set in the base config.
-    expect(overrides[0].jsPlugins).toBeUndefined();
+    // jsPlugins is also present in the override (redundant with base, but ensures
+    // oxlint can resolve the rule name regardless of config structure).
+    expect(overrides[0].jsPlugins).toStrictEqual(['eslint-plugin-regexp']);
 
     // Should be set to off in the override.
     expect(overrides[0].rules?.['regexp/no-lazy-ends']).toBe('off');

--- a/src/plugin_rules.spec.ts
+++ b/src/plugin_rules.spec.ts
@@ -334,8 +334,9 @@ describe('rules and plugins', () => {
       expect(overrideTarget.rules?.['regexp/no-lazy-ends']).toStrictEqual([
         'off',
       ]);
-      // plugin should not be added for a disabled rule in an override
-      expect(overrideTarget.jsPlugins).toBeUndefined();
+      // plugin is added even for a disabled rule in an override,
+      // so oxlint can resolve the rule name
+      expect(overrideTarget.jsPlugins).toContain('eslint-plugin-regexp');
 
       expect(reporter.getWarnings()).toStrictEqual([]);
     });

--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -240,7 +240,7 @@ export const transformRuleEntry = (
       // For unsupported rules, when jsPlugins is enabled, always try to map
       // them to a JS plugin rule, regardless of severity (including 'off').
       if (options?.jsPlugins) {
-        // If the rule is disabled, avoid enabling the jsPlugin to prevent noise.
+        // If the rule is disabled, in base config, avoid enabling the jsPlugin to prevent noise.
         if (isOffValue(normalizedConfig)) {
           // Use the resolved (potentially renamed) rule name for consistency
           // with enabled rules that go through enableJsPluginRule.
@@ -249,9 +249,15 @@ export const transformRuleEntry = (
             // base config: drop disabled rule entirely
             delete targetConfig.rules[resolvedRule];
           } else {
-            // override: keep the disabled setting without adding jsPlugin, unless plugin is ignored
+            // override: keep the disabled rule and add the jsPlugin
+            // so oxlint can resolve the rule name
             if (!isIgnoredPluginRule(rule)) {
-              targetConfig.rules[resolvedRule] = normalizedConfig;
+              enableJsPluginRule(
+                targetConfig,
+                resolvedRule,
+                normalizedConfig,
+                effectivePlugins
+              );
             }
           }
           // also remove any previously queued unsupported report for base


### PR DESCRIPTION
When a rule from a JS plugin is switched off in an override, keep the plugin listed in `jsPlugins` for that override, so that Oxlint can resolve the plugin name from the rule name.

Prior to this PR, `jsPlugins` array in the override would have been removed in this example:

```json
{
  "jsPlugins": ["eslint-plugin-foo"],
  "rules": {
    "foo/no-foo": "error"
  },
  "overrides": [{
    "files": ["*.js"],
    "jsPlugins": ["eslint-plugin-foo"],
    "rules": {
      "foo/no-foo": "off"
    }
  }]
}
```

I'm not sure if Oxlint requires the `jsPlugins` entry to exist in the override right now, but if it doesn't, it should!

It's possible (although weird) to include the same plugin twice in a config, but with different aliases. Oxlint should resolve the rule names in an override by reference to the `jsPlugins` list in the override, not the base config.

Actually, if people start using shared configs, it may not even be so weird. Same plugin under different aliases in config could easily happen, and we'll need to handle it.

So, even if this isn't necessary right now because Oxlint's logic is not so rigorous, it'll at least make configs created by `@oxlint/migrate` forwards-compatible if we close that hole later on.
