### PR TITLE
fix: Do not port `eslint/sort-imports`.

### DIFF
--- a/integration_test/__snapshots__/autoprefixer.spec.ts.snap
+++ b/integration_test/__snapshots__/autoprefixer.spec.ts.snap
@@ -275,7 +275,6 @@ exports[`autoprefixer > autoprefixer 1`] = `
       "perfectionist/sort-interfaces",
       "perfectionist/sort-jsx-props",
       "perfectionist/sort-classes",
-      "perfectionist/sort-imports",
       "perfectionist/sort-exports",
       "perfectionist/sort-objects",
       "perfectionist/sort-enums",
@@ -318,7 +317,11 @@ exports[`autoprefixer > autoprefixer 1`] = `
       "no-undef-init",
     ],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -613,30 +616,6 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
           "type": "alphabetical",
         },
       ],
-      "perfectionist/sort-imports": [
-        "warn",
-        {
-          "groups": [
-            "side-effect",
-            "side-effect-style",
-            "style",
-            [
-              "builtin",
-              "external",
-              "unknown",
-            ],
-            [
-              "internal",
-              "parent",
-              "sibling",
-              "index",
-            ],
-          ],
-          "newlinesBetween": 1,
-          "order": "asc",
-          "type": "alphabetical",
-        },
-      ],
       "perfectionist/sort-interfaces": [
         "warn",
         {
@@ -786,7 +765,11 @@ exports[`autoprefixer --js-plugins > autoprefixer--js-plugins 1`] = `
       "no-undef-init",
     ],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -1065,7 +1048,6 @@ exports[`autoprefixer --type-aware > autoprefixer--type-aware 1`] = `
       "perfectionist/sort-interfaces",
       "perfectionist/sort-jsx-props",
       "perfectionist/sort-classes",
-      "perfectionist/sort-imports",
       "perfectionist/sort-exports",
       "perfectionist/sort-objects",
       "perfectionist/sort-enums",
@@ -1108,7 +1090,11 @@ exports[`autoprefixer --type-aware > autoprefixer--type-aware 1`] = `
       "no-undef-init",
     ],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -1344,7 +1330,6 @@ exports[`autoprefixer merge > autoprefixer--merge 1`] = `
       "perfectionist/sort-interfaces",
       "perfectionist/sort-jsx-props",
       "perfectionist/sort-classes",
-      "perfectionist/sort-imports",
       "perfectionist/sort-exports",
       "perfectionist/sort-objects",
       "perfectionist/sort-enums",
@@ -1387,6 +1372,10 @@ exports[`autoprefixer merge > autoprefixer--merge 1`] = `
       "no-undef-init",
     ],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;

--- a/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
+++ b/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
@@ -599,7 +599,6 @@ exports[`nuxt-auth > nuxt-auth 1`] = `
       "eslint-comments/no-unused-enable",
       "command/command",
       "perfectionist/sort-exports",
-      "perfectionist/sort-imports",
       "perfectionist/sort-named-exports",
       "perfectionist/sort-named-imports",
       "antfu/import-dedupe",
@@ -952,6 +951,9 @@ exports[`nuxt-auth > nuxt-auth 1`] = `
     ],
   },
   "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
@@ -1343,7 +1345,6 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "markdown/table-column-count": "error",
           "no-irregular-whitespace": "off",
           "perfectionist/sort-exports": "off",
-          "perfectionist/sort-imports": "off",
           "regexp/no-legacy-features": "off",
           "regexp/no-missing-g-flag": "off",
           "regexp/no-useless-dollar-replacements": "off",
@@ -2024,35 +2025,6 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
           "type": "natural",
         },
       ],
-      "perfectionist/sort-imports": [
-        "error",
-        {
-          "groups": [
-            "type-import",
-            [
-              "type-parent",
-              "type-sibling",
-              "type-index",
-              "type-internal",
-            ],
-            "value-builtin",
-            "value-external",
-            "value-internal",
-            [
-              "value-parent",
-              "value-sibling",
-              "value-index",
-            ],
-            "side-effect",
-            "ts-equals-import",
-            "unknown",
-          ],
-          "newlinesBetween": "ignore",
-          "newlinesInside": "ignore",
-          "order": "asc",
-          "type": "natural",
-        },
-      ],
       "perfectionist/sort-named-exports": [
         "error",
         {
@@ -2373,6 +2345,9 @@ exports[`nuxt-auth --js-plugins > nuxt-auth--js-plugins 1`] = `
     ],
   },
   "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
@@ -2979,7 +2954,6 @@ exports[`nuxt-auth --type-aware > nuxt-auth--type-aware 1`] = `
       "eslint-comments/no-unused-enable",
       "command/command",
       "perfectionist/sort-exports",
-      "perfectionist/sort-imports",
       "perfectionist/sort-named-exports",
       "perfectionist/sort-named-imports",
       "antfu/import-dedupe",
@@ -3332,6 +3306,9 @@ exports[`nuxt-auth --type-aware > nuxt-auth--type-aware 1`] = `
     ],
   },
   "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
@@ -3919,7 +3896,6 @@ exports[`nuxt-auth merge > nuxt-auth--merge 1`] = `
       "eslint-comments/no-unused-enable",
       "command/command",
       "perfectionist/sort-exports",
-      "perfectionist/sort-imports",
       "perfectionist/sort-named-exports",
       "perfectionist/sort-named-imports",
       "antfu/import-dedupe",
@@ -4272,6 +4248,9 @@ exports[`nuxt-auth merge > nuxt-auth--merge 1`] = `
     ],
   },
   "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",

--- a/integration_test/__snapshots__/vuejs-core.spec.ts.snap
+++ b/integration_test/__snapshots__/vuejs-core.spec.ts.snap
@@ -136,12 +136,6 @@ exports[`vuejs/core > vuejs/core 1`] = `
             "module",
             "require",
           ],
-          "sort-imports": [
-            "error",
-            {
-              "ignoreDeclarationSort": true,
-            },
-          ],
         },
       },
       {
@@ -355,7 +349,11 @@ exports[`vuejs/core > vuejs/core 1`] = `
     "type-aware": [],
     "unsupported": [],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -495,12 +493,6 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
             "module",
             "require",
           ],
-          "sort-imports": [
-            "error",
-            {
-              "ignoreDeclarationSort": true,
-            },
-          ],
         },
       },
       {
@@ -714,7 +706,11 @@ exports[`vuejs/core --js-plugins > vuejs/core--js-plugins 1`] = `
     "type-aware": [],
     "unsupported": [],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -854,12 +850,6 @@ exports[`vuejs/core --type-aware > vuejs/core--type-aware 1`] = `
             "module",
             "require",
           ],
-          "sort-imports": [
-            "error",
-            {
-              "ignoreDeclarationSort": true,
-            },
-          ],
         },
       },
       {
@@ -1073,7 +1063,11 @@ exports[`vuejs/core --type-aware > vuejs/core--type-aware 1`] = `
     "type-aware": [],
     "unsupported": [],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;
 
@@ -1214,12 +1208,6 @@ exports[`vuejs/core merge > vuejs/core--merge 1`] = `
             "module",
             "require",
           ],
-          "sort-imports": [
-            "error",
-            {
-              "ignoreDeclarationSort": true,
-            },
-          ],
         },
       },
       {
@@ -1432,6 +1420,10 @@ exports[`vuejs/core merge > vuejs/core--merge 1`] = `
     "type-aware": [],
     "unsupported": [],
   },
-  "warnings": [],
+  "warnings": [
+    "ESLint import-sorting rules like \`sort-imports\` were not migrated because they conflict with Oxfmt's import sorting.
+Use Oxfmt's \`sortImports\` formatter option instead. It is based on \`eslint-plugin-perfectionist/sort-imports\`, is disabled by default, and will need to be enabled.
+https://oxc.rs/docs/guide/usage/formatter/sorting.html",
+  ],
 }
 `;

--- a/src/plugin_rules.spec.ts
+++ b/src/plugin_rules.spec.ts
@@ -121,6 +121,65 @@ describe('rules and plugins', () => {
       ).toBe('error');
     });
 
+    test('does not migrate core import sorting and warns to use Oxfmt instead', () => {
+      const eslintConfig: ESLint.Config = {
+        rules: {
+          'sort-imports': ['error', { ignoreDeclarationSort: true }],
+        },
+      };
+
+      const config: OxlintConfig = {};
+      const reporter = new DefaultReporter();
+
+      transformRuleEntry(eslintConfig, config, undefined, { reporter });
+
+      expect(config.rules).toStrictEqual({});
+      expect(reporter.getWarnings()).toStrictEqual([
+        "ESLint import-sorting rules like `sort-imports` were not migrated because they conflict with Oxfmt's import sorting.\n" +
+          "Use Oxfmt's `sortImports` formatter option instead. It is based on `eslint-plugin-perfectionist/sort-imports`, is disabled by default, and will need to be enabled.\n" +
+          'https://oxc.rs/docs/guide/usage/formatter/sorting.html',
+      ]);
+      expect(reporter.getSkippedRulesByCategory()).toStrictEqual({
+        nursery: [],
+        'type-aware': [],
+        'not-implemented': [],
+        'js-plugins': [],
+        unsupported: [],
+      });
+    });
+
+    test('does not migrate perfectionist import sorting and warns to use Oxfmt instead', () => {
+      const eslintConfig: ESLint.Config = {
+        plugins: { perfectionist: {} },
+        rules: {
+          'perfectionist/sort-imports': 'error',
+        },
+      };
+
+      const config: OxlintConfig = {};
+      const reporter = new DefaultReporter();
+
+      transformRuleEntry(eslintConfig, config, undefined, {
+        reporter,
+        jsPlugins: true,
+      });
+
+      expect(config.rules).toStrictEqual({});
+      expect(config.jsPlugins).toBeUndefined();
+      expect(reporter.getWarnings()).toStrictEqual([
+        "ESLint import-sorting rules like `sort-imports` were not migrated because they conflict with Oxfmt's import sorting.\n" +
+          "Use Oxfmt's `sortImports` formatter option instead. It is based on `eslint-plugin-perfectionist/sort-imports`, is disabled by default, and will need to be enabled.\n" +
+          'https://oxc.rs/docs/guide/usage/formatter/sorting.html',
+      ]);
+      expect(reporter.getSkippedRulesByCategory()).toStrictEqual({
+        nursery: [],
+        'type-aware': [],
+        'not-implemented': [],
+        'js-plugins': [],
+        unsupported: [],
+      });
+    });
+
     test('eslint rules remapped to typescript equivalents when type-aware is enabled', () => {
       // dot-notation and consistent-return are unsupported as plain ESLint rules in oxlint,
       // but oxlint supports them as @typescript-eslint type-aware rules.

--- a/src/plugins_rules.ts
+++ b/src/plugins_rules.ts
@@ -22,6 +22,12 @@ import { buildUnsupportedRuleExplanations, isEqualDeep } from './utilities.js';
 
 const allRules = Object.values(rules).flat();
 const unsupportedRuleExplanations = buildUnsupportedRuleExplanations();
+const OXFMT_SORTING_DOCS_URL =
+  'https://oxc.rs/docs/guide/usage/formatter/sorting.html';
+const oxfmtImportSortingRules = new Set([
+  'sort-imports',
+  'perfectionist/sort-imports',
+]);
 
 /**
  * checks if value is validSet, or if validSet is an array, check if value is first value of it
@@ -41,6 +47,17 @@ export const isOffValue = (value: unknown) => isValueInSet(value, ['off', 0]);
 const isWarnValue = (value: unknown) => isValueInSet(value, ['warn', 1]);
 
 const isErrorValue = (value: unknown) => isValueInSet(value, ['error', 2]);
+
+const isOxfmtImportSortingRule = (rule: string): boolean =>
+  oxfmtImportSortingRules.has(rule);
+
+const addOxfmtImportSortingWarning = (options?: Options): void => {
+  options?.reporter?.addWarning(
+    "ESLint import-sorting rules like `sort-imports` were not migrated because they conflict with Oxfmt's import sorting.\n" +
+      "Use Oxfmt's `sortImports` formatter option instead. It is based on `eslint-plugin-perfectionist/sort-imports`, is disabled by default, and will need to be enabled.\n" +
+      OXFMT_SORTING_DOCS_URL
+  );
+};
 
 const normalizeSeverityValue = (
   value: ESLint.RuleConfig | undefined
@@ -193,6 +210,13 @@ export const transformRuleEntry = (
         : originalRule;
 
     const normalizedConfig = normalizeSeverityValue(config)!;
+
+    if (isOxfmtImportSortingRule(rule)) {
+      if (isActiveValue(normalizedConfig)) {
+        addOxfmtImportSortingWarning(options);
+      }
+      continue;
+    }
 
     // removing rules from previous "overrides"
     // only works on non-merge because `overrides` is already prefilled from previous result.


### PR DESCRIPTION
We received reports for Vite+ that `eslint/sort-imports` conflicts with people's Oxfmt setup. This PR changes the migration to ignore import sorting rules, and hints at Oxfmt's `sortImports` config option.