### PR TITLE
chore: Add warning when more than 10 globals are added

### DIFF
--- a/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
+++ b/integration_test/__snapshots__/nuxt-auth.spec.ts.snap
@@ -971,6 +971,7 @@ https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
+    "Added 14 globals to the root config. This may happen when your ESLint config uses a different version of the \`globals\` package than @oxlint/migrate. Try updating \`globals\` and rerun the migration to get a simpler config.",
   ],
 }
 `;
@@ -2385,6 +2386,7 @@ https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
+    "Added 14 globals to the root config. This may happen when your ESLint config uses a different version of the \`globals\` package than @oxlint/migrate. Try updating \`globals\` and rerun the migration to get a simpler config.",
   ],
 }
 `;
@@ -3360,6 +3362,7 @@ https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
+    "Added 14 globals to the root config. This may happen when your ESLint config uses a different version of the \`globals\` package than @oxlint/migrate. Try updating \`globals\` and rerun the migration to get a simpler config.",
   ],
 }
 `;
@@ -4316,6 +4319,7 @@ https://oxc.rs/docs/guide/usage/formatter/sorting.html",
     "special parser detected: vue-eslint-parser",
     "special parser detected: toml-eslint-parser",
     "ignore list inside overrides is not supported",
+    "Added 14 globals to the root config. This may happen when your ESLint config uses a different version of the \`globals\` package than @oxlint/migrate. Try updating \`globals\` and rerun the migration to get a simpler config.",
   ],
 }
 `;

--- a/src/env_globals.spec.ts
+++ b/src/env_globals.spec.ts
@@ -6,13 +6,16 @@ import {
   removeGlobalsWithAreCoveredByEnv,
   transformEnvAndGlobals,
   transformEslintGlobalAccessToOxlintGlobalValue,
+  warnAboutLargeRootGlobals,
 } from './env_globals.js';
 import type {
   ESLint,
   OxlintConfig,
   OxlintConfigGlobalsValue,
 } from './types.js';
+import { DefaultReporter } from './reporter.js';
 import globals from 'globals';
+import { OxlintGlobals } from 'oxlint';
 
 const transformNPMGlobalsToOxlintGlobals = (
   npmGlobals: Record<string, boolean>
@@ -167,6 +170,77 @@ describe('transformEnvAndGlobals', () => {
         },
       ],
     });
+  });
+});
+
+describe('warnAboutLargeRootGlobals', () => {
+  const makeGlobals = (count: number): ESLint.GlobalsConfig & OxlintGlobals =>
+    Object.fromEntries(
+      Array.from({ length: count }, (_, i) => [`global${i + 1}`, 'readonly'])
+    );
+
+  test('warns when source and final root globals both exceed threshold', () => {
+    const reporter = new DefaultReporter();
+    const configs: ESLint.Config[] = [
+      { languageOptions: { globals: makeGlobals(11) } },
+    ];
+    const oxlintConfig: OxlintConfig = { globals: makeGlobals(11) };
+
+    warnAboutLargeRootGlobals(configs, oxlintConfig, { reporter });
+
+    const warnings = reporter.getWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Added 11 globals to the root config.');
+    expect(warnings[0]).toContain('different version of the `globals` package');
+  });
+
+  test('does not warn when source root globals are 10 or fewer', () => {
+    const reporter = new DefaultReporter();
+    const configs: ESLint.Config[] = [
+      { languageOptions: { globals: makeGlobals(10) } },
+    ];
+    const oxlintConfig: OxlintConfig = { globals: makeGlobals(10) };
+
+    warnAboutLargeRootGlobals(configs, oxlintConfig, { reporter });
+
+    expect(reporter.getWarnings()).toHaveLength(0);
+  });
+
+  test('does not warn when final root globals are 10 or fewer', () => {
+    const reporter = new DefaultReporter();
+    const configs: ESLint.Config[] = [
+      { languageOptions: { globals: makeGlobals(11) } },
+    ];
+    const oxlintConfig: OxlintConfig = { globals: makeGlobals(5) };
+
+    warnAboutLargeRootGlobals(configs, oxlintConfig, { reporter });
+
+    expect(reporter.getWarnings()).toHaveLength(0);
+  });
+
+  test('ignores configs with files (overrides)', () => {
+    const reporter = new DefaultReporter();
+    const configs: ESLint.Config[] = [
+      { files: ['*.test.js'], languageOptions: { globals: makeGlobals(20) } },
+    ];
+    const oxlintConfig: OxlintConfig = { globals: makeGlobals(20) };
+
+    warnAboutLargeRootGlobals(configs, oxlintConfig, { reporter });
+
+    expect(reporter.getWarnings()).toHaveLength(0);
+  });
+
+  test('only counts source globals from root configs, not overrides', () => {
+    const reporter = new DefaultReporter();
+    const configs: ESLint.Config[] = [
+      { languageOptions: { globals: { oneGlobal: 'readonly' } } },
+      { files: ['*.ts'], languageOptions: { globals: makeGlobals(50) } },
+    ];
+    const oxlintConfig: OxlintConfig = { globals: makeGlobals(20) };
+
+    warnAboutLargeRootGlobals(configs, oxlintConfig, { reporter });
+
+    expect(reporter.getWarnings()).toHaveLength(0);
   });
 });
 

--- a/src/env_globals.ts
+++ b/src/env_globals.ts
@@ -48,6 +48,7 @@ const OTHER_SUPPORTED_ENVS = [
 
 // these parsers are supported by oxlint and should not be reported
 const SUPPORTED_ESLINT_PARSERS = ['typescript-eslint/parser'];
+const ROOT_GLOBALS_WARNING_THRESHOLD = 10;
 
 const normalizeGlobValue = (
   value: ESLint.GlobalAccess
@@ -246,6 +247,37 @@ export const transformEnvAndGlobals = (
       }
     }
   }
+};
+
+export const warnAboutLargeRootGlobals = (
+  configs: ESLint.Config[],
+  oxlintConfig: OxlintConfig,
+  options?: Options
+): void => {
+  const sourceRootGlobals = new Set<string>();
+
+  for (const config of configs) {
+    if (config.files === undefined && config.languageOptions?.globals) {
+      for (const global of Object.keys(config.languageOptions.globals)) {
+        sourceRootGlobals.add(global);
+      }
+    }
+  }
+
+  const finalRootGlobals = Object.keys(oxlintConfig.globals ?? {});
+
+  if (
+    sourceRootGlobals.size <= ROOT_GLOBALS_WARNING_THRESHOLD ||
+    finalRootGlobals.length <= ROOT_GLOBALS_WARNING_THRESHOLD
+  ) {
+    return;
+  }
+
+  options?.reporter?.addWarning(
+    `Added ${finalRootGlobals.length} globals to the root config. ` +
+      `This may happen when your ESLint config uses a different version of the \`globals\` package than @oxlint/migrate. ` +
+      `Try updating \`globals\` and rerun the migration to get a simpler config.`
+  );
 };
 
 export const cleanUpUselessOverridesEnv = (config: OxlintConfig): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {
 import {
   detectEnvironmentByGlobals,
   transformEnvAndGlobals,
+  warnAboutLargeRootGlobals,
 } from './env_globals.js';
 import { cleanUpOxlintConfig } from './cleanup.js';
 import { transformIgnorePatterns } from './ignorePatterns.js';
@@ -157,6 +158,7 @@ const buildConfig = (
   detectNeededRulesPlugins(oxlintConfig);
   detectEnvironmentByGlobals(oxlintConfig);
   cleanUpOxlintConfig(oxlintConfig);
+  warnAboutLargeRootGlobals(configs, oxlintConfig, options);
 
   // If the --type-aware flag is used and the output config contains any
   // type-aware rules, set the `typeAware` option to true.


### PR DESCRIPTION
## Summary

This PR closes https://github.com/oxc-project/oxlint-migrate/issues/369.

When the user's `globals` package version differs from what oxlint uses internally, environment detection (e.g. `browser`, `node`) can fail, leaving hundreds of explicit globals in the root config instead of a simple `env` entry. This adds a warning when more than 10 globals end up in the root config, suggesting the user update their `globals` package and rerun the migration.

Please let me know if there any feedback on my approach or the changes.

## Changes

The warning triggers when **both** conditions are met:
- The source ESLint configs provide more than 10 root-level globals (`languageOptions.globals` without `files`)
- The final oxlint root config still has more than 10 globals after env detection and cleanup

This avoids false positives in merge mode (where the existing config may already have many globals) and for override-only globals.

```sh
npx @oxlint/migrate

✨ .oxlintrc.json created with 1 rules.

🚀 Next:
     npx oxlint .

⚠️  Warnings (1):
   * Added 1119 globals to the root config. This may happen when your ESLint config uses a different version of the `globals` package than oxlint. Try updating `globals` and rerun the migration to get a simpler config.
```
