### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
   "lint-staged": {
     "*": "oxfmt --no-error-on-unmatched-pattern"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.0.4"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates