### PR TITLE
feat: map `jsx-a11y-x` to `jsx-a11y`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const rulesPrefixesForPlugins: Record<string, OxlintConfigPlugin> = {
   jest: 'jest',
   jsdoc: 'jsdoc',
   'jsx-a11y': 'jsx-a11y',
+  'jsx-a11y-x': 'jsx-a11y',
   '@next/next': 'nextjs',
   node: 'node',
   n: 'node',

--- a/src/plugins_rules.spec.ts
+++ b/src/plugins_rules.spec.ts
@@ -1267,6 +1267,7 @@ describe('rules and plugins', () => {
           'react-hooks/exhaustive-deps': 'warn',
           'react-refresh/only-export-components': 'error',
           'import-x/no-duplicates': 'error',
+          'jsx-a11y-x/no-autofocus': 'warn',
           '@next/next/no-img-element': 'error',
         },
       };
@@ -1280,6 +1281,7 @@ describe('rules and plugins', () => {
           'react/exhaustive-deps': 'warn',
           'react/only-export-components': 'error',
           'import/no-duplicates': 'error',
+          'jsx-a11y/no-autofocus': 'warn',
           'nextjs/no-img-element': 'error',
         },
       });

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -21,7 +21,7 @@ export const isEqualDeep = <T>(a: T, b: T): boolean => {
  * Builds a lookup map of unsupported rule explanations.
  * Converts oxc-style rule keys (e.g. "eslint/no-dupe-args", "react/immutability")
  * to all matching ESLint-style keys, using rulesPrefixesForPlugins for aliases
- * (e.g. react → react-hooks/react-refresh, import → import-x, node → n).
+ * (e.g. react → react-hooks/react-refresh, import → import-x, jsx-a11y → jsx-a11y-x, node → n).
  */
 export function buildUnsupportedRuleExplanations(): Record<string, string> {
   const explanations: Record<string, string> = {};


### PR DESCRIPTION
- related to https://github.com/oxc-project/oxc/issues/22264

Allows mapping `jsx-a11y-x` to `jsx-a11y`, similar to `import-x`.