### PR TITLE
fix: resolve project globals during env migration

### DIFF
--- a/bin/config-loader.ts
+++ b/bin/config-loader.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { GlobalsCatalog } from '../src/types.js';
 
 // @link <https://github.com/eslint/eslint/blob/5fd211d00b6f0fc58cf587196a432325b7b88ec2/lib/config/config-loader.js#L40-L47>
 const FLAT_CONFIG_FILENAMES = [
@@ -48,4 +50,15 @@ export const loadESLintConfig = async (filePath: string): Promise<any> => {
   // See: https://nodejs.org/en/learn/typescript/run-natively
   // If the environment is not properly configured, the runtime will throw an error when trying to import the TypeScript file
   return import(url);
+};
+
+export const loadProjectGlobalsCatalog = (
+  eslintConfigPath: string
+): GlobalsCatalog | undefined => {
+  try {
+    const require = createRequire(eslintConfigPath);
+    return require('globals');
+  } catch {
+    return undefined;
+  }
 };

--- a/bin/oxlint-migrate.spec.ts
+++ b/bin/oxlint-migrate.spec.ts
@@ -1,6 +1,13 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
+import globals from 'globals';
 import { describe, expect, it } from 'vitest';
 
 const runMigrate = (args: string[]) => {
@@ -123,6 +130,58 @@ describe('oxlint-migrate CLI defaults', () => {
         'error',
         { ignorePartial: false },
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the project globals package to collapse globals to env', () => {
+    const cwd = process.cwd();
+    const tempDir = mkdtempSync(path.join(cwd, '.tmp-oxlint-migrate-cli-'));
+    const configPath = path.join(tempDir, 'eslint.config.mjs');
+    const outputPath = path.join(tempDir, 'out.json');
+    const projectGlobalsPath = path.join(tempDir, 'node_modules/globals');
+    const browserEntries = Object.entries(globals.browser);
+    const browserGlobals = Object.fromEntries(
+      browserEntries.slice(0, Math.floor(browserEntries.length * 0.95))
+    );
+
+    try {
+      mkdirSync(projectGlobalsPath, { recursive: true });
+      writeFileSync(
+        path.join(projectGlobalsPath, 'package.json'),
+        JSON.stringify({ name: 'globals', version: '0.0.0', main: 'index.js' }),
+        'utf8'
+      );
+      writeFileSync(
+        path.join(projectGlobalsPath, 'index.js'),
+        `module.exports = ${JSON.stringify({ browser: browserGlobals })};\n`,
+        'utf8'
+      );
+      writeFileSync(
+        configPath,
+        `import globals from 'globals';
+
+export default {
+  languageOptions: {
+    globals: {
+      ...globals.browser,
+    },
+  },
+};
+`,
+        'utf8'
+      );
+
+      runMigrate([
+        path.relative(cwd, configPath),
+        '--output-file',
+        path.relative(cwd, outputPath),
+      ]);
+
+      const output = JSON.parse(readFileSync(outputPath, 'utf8'));
+      expect(output.env.browser).toBe(true);
+      expect(output.globals).toBeUndefined();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/bin/oxlint-migrate.ts
+++ b/bin/oxlint-migrate.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   getAutodetectedEslintConfigName,
   loadESLintConfig,
+  loadProjectGlobalsCatalog,
 } from './config-loader.js';
 import main from '../src/index.js';
 import packageJson from '../package.json' with { type: 'json' };
@@ -142,6 +143,11 @@ program
     const resetPreFix = await preFixForJsPlugins();
     const eslintConfigs = await loadESLintConfig(filePath);
     resetPreFix();
+    const globalsCatalog = loadProjectGlobalsCatalog(filePath);
+
+    if (globalsCatalog !== undefined) {
+      options.globalsCatalogs = [globalsCatalog];
+    }
 
     let config;
     if (options.merge && existsSync(oxlintFilePath)) {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -15,6 +15,7 @@ import {
   replaceTypescriptAliasRules,
 } from './plugins_rules.js';
 import type {
+  Options,
   OxlintConfig,
   OxlintConfigOrOverride,
   OxlintConfigOverride,
@@ -94,8 +95,11 @@ const cleanUpUselessOverridesEntries = (config: OxlintConfig): void => {
   }
 };
 
-export const cleanUpOxlintConfig = (config: OxlintConfigOrOverride): void => {
-  removeGlobalsWithAreCoveredByEnv(config);
+export const cleanUpOxlintConfig = (
+  config: OxlintConfigOrOverride,
+  options?: Options
+): void => {
+  removeGlobalsWithAreCoveredByEnv(config, options);
   transformBoolGlobalToString(config);
   replaceTypescriptAliasRules(config);
   replaceCanonicalPluginPrefixes(config);

--- a/src/env_globals.spec.ts
+++ b/src/env_globals.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './env_globals.js';
 import type {
   ESLint,
+  GlobalsCatalog,
   OxlintConfig,
   OxlintConfigGlobalsValue,
 } from './types.js';
@@ -26,6 +27,15 @@ const transformNPMGlobalsToOxlintGlobals = (
       transformEslintGlobalAccessToOxlintGlobalValue(value),
     ])
   );
+};
+
+const makeOlderBrowserGlobalsCatalog = (): GlobalsCatalog => {
+  const browserEntries = Object.entries(globals.browser);
+  const keyCount = Math.floor(browserEntries.length * 0.95);
+
+  return {
+    browser: Object.fromEntries(browserEntries.slice(0, keyCount)),
+  };
 };
 
 describe('detectEnvironmentByGlobals', () => {
@@ -92,6 +102,21 @@ describe('detectEnvironmentByGlobals', () => {
     detectEnvironmentByGlobals(config);
     expect(config.env?.browser).toBeUndefined();
   });
+
+  test('detects env with a project globals catalog when bundled globals differ by >3%', () => {
+    const projectGlobalsCatalog = makeOlderBrowserGlobalsCatalog();
+    const config: OxlintConfig = {
+      globals: transformNPMGlobalsToOxlintGlobals(
+        projectGlobalsCatalog.browser
+      ),
+    };
+
+    detectEnvironmentByGlobals(config, {
+      globalsCatalogs: [projectGlobalsCatalog],
+    });
+
+    expect(config.env?.browser).toBe(true);
+  });
 });
 
 describe('removeGlobalsWithAreCoveredByEnv', () => {
@@ -105,6 +130,47 @@ describe('removeGlobalsWithAreCoveredByEnv', () => {
 
     removeGlobalsWithAreCoveredByEnv(config);
     expect(config.globals).toBeUndefined();
+  });
+
+  test('removes globals covered by a project globals catalog', () => {
+    const projectGlobalsCatalog = makeOlderBrowserGlobalsCatalog();
+    const config: OxlintConfig = {
+      env: {
+        browser: true,
+      },
+      globals: transformNPMGlobalsToOxlintGlobals(
+        projectGlobalsCatalog.browser
+      ),
+    };
+
+    removeGlobalsWithAreCoveredByEnv(config, {
+      globalsCatalogs: [projectGlobalsCatalog],
+    });
+
+    expect(config.globals).toBeUndefined();
+  });
+
+  test('keeps globals that differ from a detected project globals catalog', () => {
+    const projectGlobalsCatalog = makeOlderBrowserGlobalsCatalog();
+    const config: OxlintConfig = {
+      env: {
+        browser: true,
+      },
+      globals: {
+        ...transformNPMGlobalsToOxlintGlobals(projectGlobalsCatalog.browser),
+        document: 'off',
+        ProjectGlobal: 'readonly',
+      },
+    };
+
+    removeGlobalsWithAreCoveredByEnv(config, {
+      globalsCatalogs: [projectGlobalsCatalog],
+    });
+
+    expect(config.globals).toStrictEqual({
+      document: 'off',
+      ProjectGlobal: 'readonly',
+    });
   });
 });
 

--- a/src/env_globals.ts
+++ b/src/env_globals.ts
@@ -1,6 +1,7 @@
 import globals from 'globals';
 import type {
   ESLint,
+  GlobalsCatalog,
   Options,
   OxlintConfig,
   OxlintConfigGlobalsValue,
@@ -50,6 +51,11 @@ const OTHER_SUPPORTED_ENVS = [
 const SUPPORTED_ESLINT_PARSERS = ['typescript-eslint/parser'];
 const ROOT_GLOBALS_WARNING_THRESHOLD = 10;
 
+const getGlobalsCatalogs = (options?: Options): GlobalsCatalog[] => [
+  ...(options?.globalsCatalogs ?? []),
+  globals,
+];
+
 const normalizeGlobValue = (
   value: ESLint.GlobalAccess
 ): boolean | undefined => {
@@ -67,7 +73,8 @@ const normalizeGlobValue = (
 // In Eslint v9 there are no envs and all are build in with `globals` package
 // we look what environment is supported and remove all globals which fall under it
 export const removeGlobalsWithAreCoveredByEnv = (
-  config: OxlintConfigOrOverride
+  config: OxlintConfigOrOverride,
+  options?: Options
 ) => {
   if (
     config.globals === undefined ||
@@ -78,10 +85,13 @@ export const removeGlobalsWithAreCoveredByEnv = (
     return;
   }
 
-  for (const [env, entries] of Object.entries(globals)) {
-    if (config.env[env] === true) {
+  for (const globalsCatalog of getGlobalsCatalogs(options)) {
+    for (const [env, entries] of Object.entries(globalsCatalog)) {
+      if (config.env[env] !== true) {
+        continue;
+      }
+
       for (const entry of Object.keys(entries)) {
-        // @ts-expect-error -- filtering makes the key to any
         if (normalizeGlobValue(config.globals[entry]) === entries[entry]) {
           delete config.globals[entry];
         }
@@ -124,52 +134,57 @@ export const transformEslintGlobalAccessToOxlintGlobalValue = (
 // Environments we want to apply a threshold match for, because they're quite large.
 const THRESHOLD_ENVS = ['browser', 'node', 'serviceworker', 'worker'];
 
-export const detectEnvironmentByGlobals = (config: OxlintConfigOrOverride) => {
+export const detectEnvironmentByGlobals = (
+  config: OxlintConfigOrOverride,
+  options?: Options
+) => {
   if (config.globals === undefined || config.globals === null) {
     return;
   }
 
-  for (const [env, entries] of Object.entries(globals)) {
-    if (!env.startsWith('es') && !OTHER_SUPPORTED_ENVS.includes(env)) {
-      continue;
-    }
-
-    // skip unsupported oxlint EcmaScript versions
-    if (
-      env.startsWith('es') &&
-      !ES_VERSIONS.includes(parseInt(env.replace(/^es/, '')))
-    ) {
-      continue;
-    }
-
-    let search = Object.keys(entries);
-
-    let matches = search.filter(
-      (entry) =>
-        // @ts-expect-error -- we already checked for undefined
-        entry in config.globals &&
-        // @ts-expect-error -- filtering makes the key to any
-        normalizeGlobValue(config.globals[entry]) === entries[entry]
-    );
-
-    // For especially large globals, we allow a match if >=97% of keys match.
-    // This lets us handle version differences in globals package where
-    // there's a difference of just a few extra/removed keys.
-    // Do not do any other envs, otherwise things like es2024 and es2026
-    // would match each other.
-    const useThreshold = THRESHOLD_ENVS.includes(env);
-
-    const withinThreshold =
-      useThreshold && matches.length / search.length >= 0.97;
-
-    if (
-      withinThreshold ||
-      (!useThreshold && matches.length === search.length)
-    ) {
-      if (config.env === undefined || config.env === null) {
-        config.env = {};
+  for (const globalsCatalog of getGlobalsCatalogs(options)) {
+    for (const [env, entries] of Object.entries(globalsCatalog)) {
+      if (!env.startsWith('es') && !OTHER_SUPPORTED_ENVS.includes(env)) {
+        continue;
       }
-      config.env[env] = true;
+
+      // skip unsupported oxlint EcmaScript versions
+      if (
+        env.startsWith('es') &&
+        !ES_VERSIONS.includes(parseInt(env.replace(/^es/, '')))
+      ) {
+        continue;
+      }
+
+      let search = Object.keys(entries);
+
+      let matches = search.filter(
+        (entry) =>
+          // @ts-expect-error -- we already checked for undefined
+          entry in config.globals &&
+          // @ts-expect-error -- filtering makes the key to any
+          normalizeGlobValue(config.globals[entry]) === entries[entry]
+      );
+
+      // For especially large globals, we allow a match if >=97% of keys match.
+      // This lets us handle version differences in globals package where
+      // there's a difference of just a few extra/removed keys.
+      // Do not do any other envs, otherwise things like es2024 and es2026
+      // would match each other.
+      const useThreshold = THRESHOLD_ENVS.includes(env);
+
+      const withinThreshold =
+        useThreshold && matches.length / search.length >= 0.97;
+
+      if (
+        withinThreshold ||
+        (!useThreshold && matches.length === search.length)
+      ) {
+        if (config.env === undefined || config.env === null) {
+          config.env = {};
+        }
+        config.env[env] = true;
+      }
     }
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,16 +148,16 @@ const buildConfig = (
     // clean up overrides
     if ('files' in targetConfig) {
       detectNeededRulesPlugins(targetConfig);
-      detectEnvironmentByGlobals(targetConfig);
-      cleanUpOxlintConfig(targetConfig);
+      detectEnvironmentByGlobals(targetConfig, options);
+      cleanUpOxlintConfig(targetConfig, options);
     }
   }
 
   oxlintConfig.overrides = overrides;
 
   detectNeededRulesPlugins(oxlintConfig);
-  detectEnvironmentByGlobals(oxlintConfig);
-  cleanUpOxlintConfig(oxlintConfig);
+  detectEnvironmentByGlobals(oxlintConfig, options);
+  cleanUpOxlintConfig(oxlintConfig, options);
   warnAboutLargeRootGlobals(configs, oxlintConfig, options);
 
   // If the --type-aware flag is used and the output config contains any

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,10 +177,13 @@ export type Reporter = {
   getSkippedRulesByCategory(): SkippedCategoryGroup;
 };
 
+export type GlobalsCatalog = Record<string, Record<string, boolean>>;
+
 export type Options = {
   reporter?: Reporter;
   merge?: boolean;
   withNursery?: boolean;
   typeAware?: boolean;
   jsPlugins?: boolean;
+  globalsCatalogs?: GlobalsCatalog[];
 };


### PR DESCRIPTION
Right now we get globals mismatches in case they don't match to >=97% to the most modern one.
This results in a huge list of globals being added which is not wanted.

Instead, this PR resolves the project's own `globals` package from the ESLint config path and uses it for env detection as additional source.
This should reduce the manual inlining.