### PR TITLE
chore(renovate): set minimum release age age to one day

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "github>Boshen/renovate",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "groupName": "npm packages",


### PR DESCRIPTION
Since pnpm 11.0 the minimum release age is 1 day. 
Renovate try currently to create PRs which includes packages under this threshold. 

https://pnpm.io/blog/releases/11.0