### PR TITLE
feat: warn when type-aware flag is used and tsconfig has baseUrl

### DIFF
--- a/bin/oxlint-migrate.spec.ts
+++ b/bin/oxlint-migrate.spec.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -12,6 +12,34 @@ const runMigrate = (args: string[]) => {
       stdio: 'pipe',
     }
   );
+};
+
+const projectRoot = process.cwd();
+const cliScript = path.join(projectRoot, 'bin', 'oxlint-migrate.ts');
+
+const runMigrateWithStderr = (
+  args: string[],
+  options?: { cwd?: string }
+): { stdout: string; stderr: string } => {
+  const result = spawnSync(
+    process.execPath,
+    ['--import', '@oxc-node/core/register', cliScript, ...args],
+    {
+      cwd: options?.cwd ?? projectRoot,
+      stdio: 'pipe',
+    }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.status}: ${result.stderr?.toString()}`
+    );
+  }
+
+  return {
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+  };
 };
 
 describe('oxlint-migrate CLI defaults', () => {
@@ -123,6 +151,139 @@ describe('oxlint-migrate CLI defaults', () => {
         'error',
         { ignorePartial: false },
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('--type-aware baseUrl warning', () => {
+  const eslintConfigContent = `export default {
+  rules: {
+    '@typescript-eslint/no-floating-promises': 'error',
+  },
+};
+`;
+
+  it('prints a warning when --type-aware is used and tsconfig.json has baseUrl', () => {
+    const tempDir = mkdtempSync(
+      path.join(projectRoot, '.tmp-oxlint-migrate-cli-')
+    );
+    const tsconfigPath = path.join(tempDir, 'tsconfig.json');
+
+    try {
+      writeFileSync(
+        path.join(tempDir, 'eslint.config.mjs'),
+        eslintConfigContent,
+        'utf8'
+      );
+      writeFileSync(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            strict: true,
+          },
+        }),
+        'utf8'
+      );
+
+      const { stderr } = runMigrateWithStderr(
+        ['eslint.config.mjs', '--output-file', 'out.json', '--type-aware'],
+        { cwd: tempDir }
+      );
+
+      expect(stderr).toContain('baseUrl');
+      expect(stderr).toContain('tsgo');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print a warning when --type-aware is not used', () => {
+    const tempDir = mkdtempSync(
+      path.join(projectRoot, '.tmp-oxlint-migrate-cli-')
+    );
+    const tsconfigPath = path.join(tempDir, 'tsconfig.json');
+
+    try {
+      writeFileSync(
+        path.join(tempDir, 'eslint.config.mjs'),
+        eslintConfigContent,
+        'utf8'
+      );
+      writeFileSync(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            strict: true,
+          },
+        }),
+        'utf8'
+      );
+
+      const { stderr } = runMigrateWithStderr(
+        ['eslint.config.mjs', '--output-file', 'out.json'],
+        { cwd: tempDir }
+      );
+
+      expect(stderr).not.toContain('baseUrl');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print a warning when tsconfig.json has no baseUrl', () => {
+    const tempDir = mkdtempSync(
+      path.join(projectRoot, '.tmp-oxlint-migrate-cli-')
+    );
+    const tsconfigPath = path.join(tempDir, 'tsconfig.json');
+
+    try {
+      writeFileSync(
+        path.join(tempDir, 'eslint.config.mjs'),
+        eslintConfigContent,
+        'utf8'
+      );
+      writeFileSync(
+        tsconfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            strict: true,
+          },
+        }),
+        'utf8'
+      );
+
+      const { stderr } = runMigrateWithStderr(
+        ['eslint.config.mjs', '--output-file', 'out.json', '--type-aware'],
+        { cwd: tempDir }
+      );
+
+      expect(stderr).not.toContain('baseUrl');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print a warning when tsconfig.json does not exist', () => {
+    const tempDir = mkdtempSync(
+      path.join(projectRoot, '.tmp-oxlint-migrate-cli-')
+    );
+    try {
+      writeFileSync(
+        path.join(tempDir, 'eslint.config.mjs'),
+        eslintConfigContent,
+        'utf8'
+      );
+
+      const { stderr } = runMigrateWithStderr(
+        ['eslint.config.mjs', '--output-file', 'out.json', '--type-aware'],
+        { cwd: tempDir }
+      );
+
+      expect(stderr).not.toContain('baseUrl');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/bin/oxlint-migrate.ts
+++ b/bin/oxlint-migrate.ts
@@ -35,6 +35,48 @@ const getFileContent = (absoluteFilePath: string): string | undefined => {
 };
 
 /**
+ * Strips JSON comments (single-line `//` and multi-line) and trailing commas
+ * so that `tsconfig.json` (which is actually JSONC) can be parsed with `JSON.parse`.
+ */
+const stripJsoncFeatures = (text: string): string =>
+  text
+    // Remove single-line comments
+    .replace(/\/\/.*$/gm, '')
+    // Remove multi-line comments
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    // Remove trailing commas before } or ]
+    .replace(/,\s*([}\]])/g, '$1');
+
+/**
+ * When `--type-aware` is used, check whether the project's `tsconfig.json`
+ * contains a `baseUrl` value in `compilerOptions`. If it does, emit a warning
+ * because `tsgo` does not support `baseUrl`, which may cause issues with
+ * type-aware linting.
+ */
+const warnIfTsconfigHasBaseUrl = (reporter: DefaultReporter): void => {
+  const tsconfigPath = path.join(cwd, 'tsconfig.json');
+  const content = getFileContent(tsconfigPath);
+
+  if (content === undefined) {
+    return;
+  }
+
+  try {
+    const tsconfig = JSON.parse(stripJsoncFeatures(content));
+
+    if (tsconfig?.compilerOptions?.baseUrl !== undefined) {
+      reporter.addWarning(
+        `tsconfig.json has \`baseUrl\` set to ${JSON.stringify(tsconfig.compilerOptions.baseUrl)}. ` +
+          `\`baseUrl\` is not supported by tsgo, which may cause issues with type-aware linting. ` +
+          `Consider removing \`baseUrl\` or using path aliases instead.`
+      );
+    }
+  } catch {
+    // If tsconfig.json can't be parsed, silently ignore — it's not critical.
+  }
+};
+
+/**
  * Count enabled rules (excluding "off" rules) from both rules and overrides
  */
 const countEnabledRules = (config: OxlintConfig): number => {
@@ -115,6 +157,12 @@ program
       typeAware: !!cliOptions.typeAware,
       jsPlugins,
     };
+
+    // Warn if --type-aware is used and tsconfig.json has baseUrl set,
+    // since tsgo does not support baseUrl.
+    if (options.typeAware) {
+      warnIfTsconfigHasBaseUrl(reporter);
+    }
 
     if (cliOptions.replaceEslintComments) {
       await walkAndReplaceProjectFiles(


### PR DESCRIPTION
Resolves #450.

This PR adds a warning when running `oxlint-migrate` with the `--type-aware` flag if the project's `tsconfig.json` contains a `baseUrl` configuration.

Since `tsgo` does not support `baseUrl`, migrating type-aware rules in these projects can lead to unexpected issues. Adding this warning makes the migration process cleaner and provides immediate feedback to the user.

**Changes:**
- Added a `warnIfTsconfigHasBaseUrl` check that safely parses `tsconfig.json` (stripping JSONC comments and trailing commas) to check for `compilerOptions.baseUrl`.
- Integrated the check into the CLI action handler so it runs specifically when `--type-aware` is enabled.
- Added comprehensive unit tests in `bin/oxlint-migrate.spec.ts` covering various scenarios (e.g. flag usage, `baseUrl` presence/absence and missing `tsconfig.json`).