### PR TITLE
fix: Update minimumReleaseAgeExclude to include all @oxlint packages, oxc-parser, oxfmt

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,23 +3,7 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
 minimumReleaseAgeExclude:
-  - '@oxlint/binding-android-arm-eabi'
-  - '@oxlint/binding-android-arm64'
-  - '@oxlint/binding-darwin-arm64'
-  - '@oxlint/binding-darwin-x64'
-  - '@oxlint/binding-freebsd-x64'
-  - '@oxlint/binding-linux-arm-gnueabihf'
-  - '@oxlint/binding-linux-arm-musleabihf'
-  - '@oxlint/binding-linux-arm64-gnu'
-  - '@oxlint/binding-linux-arm64-musl'
-  - '@oxlint/binding-linux-ppc64-gnu'
-  - '@oxlint/binding-linux-riscv64-gnu'
-  - '@oxlint/binding-linux-riscv64-musl'
-  - '@oxlint/binding-linux-s390x-gnu'
-  - '@oxlint/binding-linux-x64-gnu'
-  - '@oxlint/binding-linux-x64-musl'
-  - '@oxlint/binding-openharmony-arm64'
-  - '@oxlint/binding-win32-arm64-msvc'
-  - '@oxlint/binding-win32-ia32-msvc'
-  - '@oxlint/binding-win32-x64-msvc'
+  - '@oxlint/*'
   - oxlint
+  - oxfmt
+  - '@oxc-parser/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,10 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
 minimumReleaseAgeExclude:
-  - '@oxlint/*'
   - oxlint
+  - '@oxlint/*'
   - oxfmt
+  - '@oxfmt/*'
+  - '@oxc-project/types'
+  - oxc-parser
   - '@oxc-parser/*'


### PR DESCRIPTION
`@oxc-parser/` packages were failing to install due to the minimum release age after trying to update oxlint. This fixes the problem.