### PR TITLE
ci: use pnpm publish and drop global npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write # for `npm publish --provenance`
+      id-token: write # for `pnpm publish --provenance`
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -39,10 +39,8 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - run: npm install -g npm@latest # For trusted publishing support
-
       - name: Publish to NPM
-        run: npm publish --tag latest --provenance --access public
+        run: pnpm publish --tag latest --provenance --access public
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
Removes the `npm install -g npm@latest` step and switches the publish command to `pnpm publish`.

That global npm install only existed to get a recent npm for trusted publishing (OIDC provenance). With `pnpm publish` handling the publish, the globally-installed npm version is irrelevant, so the step is dropped.